### PR TITLE
Allow theme installation via init container

### DIFF
--- a/charts/business-api-ecosystem/Chart.yaml
+++ b/charts/business-api-ecosystem/Chart.yaml
@@ -3,7 +3,7 @@ name: business-api-ecosystem
 description: A Helm chart for running the FIWARE business API ecosystem (FIWARE Marketplace) on Kubernetes
 icon: https://fiware.github.io/catalogue/img/fiware.png
 version: 0.0.3
-appVersion: 7.6.1
+appVersion: 7.8.0
 home: https://business-api-ecosystem.readthedocs.io/en/latest/
 keywords:
   - fiware

--- a/charts/business-api-ecosystem/Chart.yaml
+++ b/charts/business-api-ecosystem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: business-api-ecosystem
 description: A Helm chart for running the FIWARE business API ecosystem (FIWARE Marketplace) on Kubernetes
 icon: https://fiware.github.io/catalogue/img/fiware.png
-version: 0.0.2
+version: 0.0.3
 appVersion: 7.6.1
 home: https://business-api-ecosystem.readthedocs.io/en/latest/
 keywords:

--- a/charts/business-api-ecosystem/templates/_helpers.tpl
+++ b/charts/business-api-ecosystem/templates/_helpers.tpl
@@ -328,7 +328,7 @@ Template for TMForum APIs initContainer check
 {{- end }}
 
 {{/*
-Template for CHarging Backend initContainer check
+Template for Charging Backend initContainer check
 */}}
 {{- define "business-api-ecosystem.initContainer.charging" }}
 - name: {{ tpl .name .ctx }}

--- a/charts/business-api-ecosystem/templates/biz-ecosystem-charging-backend/deployment.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-charging-backend/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: plugins
               mountPath: /business-ecosystem-charging-backend/src/plugins
             - name: inst-plugins
-              mountPath: /business-ecosystem-charging-backend/src/wstore/asset_manager/resource_plugins/plugin
+              mountPath: /business-ecosystem-charging-backend/src/wstore/asset_manager/resource_plugins/plugins
           env:
             - name: BAE_CB_PAYMENT_METHOD
               value: {{ .Values.bizEcosystemChargingBackend.payment.method | quote }}
@@ -146,6 +146,14 @@ spec:
               value: http://{{ include "bizEcosystemApis.fullhostname" . }}/DSUsageManagement
             - name: BAE_CB_AUTHORIZE_SERVICE
               value: http://{{ include "bizEcosystemLogicProxy.fullhostname" . }}{{ .Values.bizEcosystemChargingBackend.authorizeServicePath }}
+            {{- if .Values.bizEcosystemChargingBackend.plugins.enabled }}
+            - name: BAE_ASSET_IDM_USER
+              value: {{ .Values.bizEcosystemChargingBackend.plugins.idmUser | quote }}
+            - name: BAE_ASSET_IDM_PASSWORD
+              value: {{ .Values.bizEcosystemChargingBackend.plugins.idmPassword | quote }}
+            - name: BAE_ASSET_IDM_URL
+              value: {{ .Values.oauth.server | quote }}
+            {{- end }}
       {{- with .Values.bizEcosystemChargingBackend.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/deployment.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/deployment.yaml
@@ -171,6 +171,14 @@ spec:
               value: {{ include "bizEcosystemChargingBackend.hostnameonly" . }}
             - name: BAE_LP_ENDPOINT_CHARGING_PORT
               value: {{ .Values.bizEcosystemChargingBackend.service.port | quote }}
+            - name: BAE_LP_INDEX_ENGINE
+              value: {{ .Values.bizEcosystemLogicProxy.elastic.engine | quote }}
+            - name: BAE_LP_INDEX_API_VERSION
+              value: {{ .Values.bizEcosystemLogicProxy.elastic.version | quote }}
+            - name: BAE_LP_INDEX_URL
+              value: {{ .Values.bizEcosystemLogicProxy.elastic.url | quote }}
+            - name: BAE_SERVICE_HOST
+              value: {{ .Values.externalUrl | quote }}
       {{- with .Values.bizEcosystemLogicProxy.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/deployment.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/deployment.yaml
@@ -40,6 +40,15 @@ spec:
         {{- include "business-api-ecosystem.initContainer.apis" ( dict "ctx" . "name" "{{ include \"bizEcosystemLogicProxy.apiInitContainer\" . }}-customer" "path" "DSCustomerManagement" ) | nindent 8 }}
         {{- include "business-api-ecosystem.initContainer.apis" ( dict "ctx" . "name" "{{ include \"bizEcosystemLogicProxy.apiInitContainer\" . }}-usage" "path" "DSUsageManagement" ) | nindent 8 }}
         {{- include "business-api-ecosystem.initContainer.charging" ( dict "ctx" . "name" "{{ include \"bizEcosystemLogicProxy.apiInitContainer\" . }}-charging" "path" "charging/api/assetManagement/currencyCodes" ) | nindent 8 }}
+        {{- if .Values.bizEcosystemLogicProxy.theme.enabled }}
+        - name: {{ include "bizEcosystemLogicProxy.fullname" . }}-theme-init
+          image: {{ .Values.bizEcosystemLogicProxy.theme.image }}
+          imagePullPolicy: {{ .Values.bizEcosystemLogicProxy.theme.imagePullPolicy }}
+          command: ['sh', '-c', 'mkdir -p /themes/{{ .Values.bizEcosystemLogicProxy.theme.name }} && cp -r {{ .Values.bizEcosystemLogicProxy.theme.sourcePath }}/* /themes/{{ .Values.bizEcosystemLogicProxy.theme.name }}/.']
+          volumeMounts:
+            - name: themes
+              mountPath: /themes
+        {{- end }}
       containers:
         - name: {{ template "business-api-ecosystem.name" . }}-{{ .Values.bizEcosystemLogicProxy.name }}
           imagePullPolicy: {{ .Values.bizEcosystemLogicProxy.deployment.image.pullPolicy }}
@@ -68,6 +77,11 @@ spec:
             periodSeconds: {{ .Values.bizEcosystemLogicProxy.deployment.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.bizEcosystemLogicProxy.deployment.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.bizEcosystemLogicProxy.deployment.readinessProbe.timeoutSeconds }}
+          {{- if .Values.bizEcosystemLogicProxy.theme.enabled }}
+          volumeMounts:
+            - name: themes
+              mountPath: /business-ecosystem-logic-proxy/themes
+          {{- end }}
           env:
             - name: NODE_ENV
               value: {{ .Values.bizEcosystemLogicProxy.nodeEnvironment | quote }}
@@ -115,9 +129,9 @@ spec:
               value: {{ .Values.oauth.orgadminrole | quote }}
             - name: BAE_LP_OAUTH2_IS_LEGACY
               value: {{ .Values.oauth.isLegacy | quote }}
-            {{- if .Values.bizEcosystemLogicProxy.theme }}
+            {{- if .Values.bizEcosystemLogicProxy.theme.enabled }}
             - name: BAE_LP_THEME
-              value: {{ .Values.bizEcosystemLogicProxy.theme | quote }}
+              value: {{ .Values.bizEcosystemLogicProxy.theme.name | quote }}
             {{- end }}
             - name: BAE_LP_REVENUE_MODEL
               value: {{ .Values.bizEcosystemLogicProxy.revenueModel | quote }}
@@ -168,5 +182,11 @@ spec:
       {{- with .Values.bizEcosystemLogicProxy.deployment.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-      {{- end }}    
+      {{- end }}
+      {{- if .Values.bizEcosystemLogicProxy.theme.enabled }}
+      volumes:
+        - name: themes
+          persistentVolumeClaim:
+            claimName: {{ include "bizEcosystemLogicProxy.fullname" . }}-themes
+      {{- end }}
 {{- end }}

--- a/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/pvc-themes.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/pvc-themes.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.bizEcosystemLogicProxy.theme.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "bizEcosystemLogicProxy.fullname" . }}-themes
+  {{- with .Values.bizEcosystemLogicProxy.theme.annotations  }}
+  annotations:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
+  labels:
+    {{- include "bizEcosystemLogicProxy.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.bizEcosystemLogicProxy.theme.size | quote }}
+{{- end }}

--- a/charts/business-api-ecosystem/values.yaml
+++ b/charts/business-api-ecosystem/values.yaml
@@ -337,7 +337,8 @@ bizEcosystemChargingBackend:
       ## ref: https://hub.docker.com/r/fiware/biz-ecosystem-charging-backend
       repository: fiware/biz-ecosystem-charging-backend
       ## -- tag of the image to be used
-      tag: v7.6.1
+      tag: v7.8.0
+      #tag: v7.6.1
       ## -- specification of the image pull policy
       pullPolicy: IfNotPresent
     ## -- additional labels for the deployment, if required  
@@ -374,6 +375,10 @@ bizEcosystemChargingBackend:
     size: 4Gi
     ## -- Annotations
     annotations: {}
+    ## -- IDM Admin username
+    idmUser: admin
+    ## -- IDM Admin password
+    idmPassword: admin-password
     
   ## -- port that the charging backend container uses
   port: 8006
@@ -479,7 +484,8 @@ bizEcosystemLogicProxy:
       ## ref: https://hub.docker.com/r/fiware/biz-ecosystem-logic-proxy
       repository: fiware/biz-ecosystem-logic-proxy
       ## -- tag of the image to be used
-      tag: v7.6.1
+      tag: v7.8.0
+      #tag: v7.6.1
       ## -- specification of the image pull policy
       pullPolicy: IfNotPresent
     ## -- additional labels for the deployment, if required  
@@ -498,12 +504,12 @@ bizEcosystemLogicProxy:
     ## -- liveness and readiness probes
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
     livenessProbe:
-      initialDelaySeconds: 11
+      initialDelaySeconds: 61
       periodSeconds: 30
       successThreshold: 1
       timeoutSeconds: 30
     readinessProbe:
-      initialDelaySeconds: 10
+      initialDelaySeconds: 60
       periodSeconds: 30
       successThreshold: 1
       timeoutSeconds: 30
@@ -566,6 +572,15 @@ bizEcosystemLogicProxy:
     user: root
     # -- password for connecting the database
     password: pass
+
+  ## -- elasticsearch configuration
+  elastic:
+    ## -- indexing engine of logic proxy
+    engine: elasticsearch
+    ## -- URL of elasticsearch service
+    url: elasticsearch:9200
+    ## -- API version of elasticsearch
+    version: 7
 
   ## -- Custom theme configuration
   theme:

--- a/charts/business-api-ecosystem/values.yaml
+++ b/charts/business-api-ecosystem/values.yaml
@@ -235,7 +235,7 @@ bizEcosystemRss:
       ## ref: https://hub.docker.com/r/fiware/biz-ecosystem-rss
       repository: fiware/biz-ecosystem-rss
       ## -- tag of the image to be used
-      tag: v7.6.0
+      tag: v7.8.0
       ## -- specification of the image pull policy
       pullPolicy: IfNotPresent
     ## -- additional labels for the deployment, if required  
@@ -338,7 +338,6 @@ bizEcosystemChargingBackend:
       repository: fiware/biz-ecosystem-charging-backend
       ## -- tag of the image to be used
       tag: v7.8.0
-      #tag: v7.6.1
       ## -- specification of the image pull policy
       pullPolicy: IfNotPresent
     ## -- additional labels for the deployment, if required  
@@ -485,7 +484,6 @@ bizEcosystemLogicProxy:
       repository: fiware/biz-ecosystem-logic-proxy
       ## -- tag of the image to be used
       tag: v7.8.0
-      #tag: v7.6.1
       ## -- specification of the image pull policy
       pullPolicy: IfNotPresent
     ## -- additional labels for the deployment, if required  

--- a/charts/business-api-ecosystem/values.yaml
+++ b/charts/business-api-ecosystem/values.yaml
@@ -552,7 +552,7 @@ bizEcosystemLogicProxy:
   nodeEnvironment: development
   
   ## -- Execute the collect static command on startup
-  collectStaticCommand: True
+  collectStaticCommand: "True"
   
   ## -- database configuration for Logic Proxy (MongoDB)
   db:
@@ -567,8 +567,23 @@ bizEcosystemLogicProxy:
     # -- password for connecting the database
     password: pass
 
-  ## -- If provided custom theme to be used by the web site, it must be included in themes volume
-  # theme: my-theme
+  ## -- Custom theme configuration
+  theme:
+    ## -- Enable theme
+    enabled: false
+    ## -- Name of the theme
+    name: default
+    ## -- Size of PVC to be created
+    size: 4Gi
+    ## -- PVC Annotations
+    annotations: {}
+    ## Image which holds the theme files
+    image: my-theme-image:latest
+    ## -- specification of the image pull policy
+    imagePullPolicy: IfNotPresent
+    ## Path to the source theme files inside the container
+    #  Files will be copied to /themes/{{name}} with the PVC mounted at /themes
+    sourcePath: /my-theme
 
   ## -- Default market owner precentage for Revenue Sharing models
   revenueModel: 30


### PR DESCRIPTION
Themes can now be provided as images to be loaded as init containers. In the init container step, the theme files are copied to the appropriate place.
This is an example of a theme image: https://hub.docker.com/r/fiware/bae-i4trust-theme
