### PR TITLE
add volume support for sidecars

### DIFF
--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orion
-version: 0.0.11
+version: 0.0.12
 appVersion: 2.5.0
 home: https://fiware-orion.readthedocs.io/en/master/
 description: A Helm chart for running the fiware orion broker on kubernetes.

--- a/charts/orion/templates/deployment.yaml
+++ b/charts/orion/templates/deployment.yaml
@@ -301,6 +301,10 @@ spec:
       {{- if .Values.deployment.sidecars }}
         {{- toYaml .Values.deployment.sidecars | nindent 8 }}
       {{- end }}
+      {{- if .Values.deployment.volumes }}
+      volumes:
+        {{- toYaml .Values.deployment.volumes | nindent 8 }}
+      {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/orion/values.yaml
+++ b/charts/orion/values.yaml
@@ -85,6 +85,8 @@ deployment:
     timeoutSeconds: 30
   # -- additional sidepods for the deployment, if required
   sidecars: []
+  # -- additional volumes for the deployment, if required
+  volumes: []
 
 ## pod autoscaling configuration, use for automatic scaling of the broker pods
 autoscaling:


### PR DESCRIPTION
We implemented volumes for sidecars in our Orion deployment and want to share it upstream.