### PR TITLE
Add option for local IDP on modal dialog

### DIFF
--- a/charts/business-api-ecosystem/Chart.yaml
+++ b/charts/business-api-ecosystem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: business-api-ecosystem
 description: A Helm chart for running the FIWARE business API ecosystem (FIWARE Marketplace) on Kubernetes
 icon: https://fiware.github.io/catalogue/img/fiware.png
-version: 0.2.4
+version: 0.2.5
 appVersion: 8.0.0
 home: https://business-api-ecosystem.readthedocs.io/en/latest/
 keywords:

--- a/charts/business-api-ecosystem/README.md
+++ b/charts/business-api-ecosystem/README.md
@@ -1,6 +1,6 @@
 # business-api-ecosystem
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![AppVersion: 8.0.0](https://img.shields.io/badge/AppVersion-8.0.0-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![AppVersion: 8.0.0](https://img.shields.io/badge/AppVersion-8.0.0-informational?style=flat-square)
 
 A Helm chart for running the FIWARE business API ecosystem (FIWARE Marketplace) on Kubernetes
 
@@ -128,6 +128,7 @@ A Helm chart for running the FIWARE business API ecosystem (FIWARE Marketplace) 
 | bizEcosystemLogicProxy.elastic.version | int | `7` | API version of elasticsearch |
 | bizEcosystemLogicProxy.enabled | bool | `true` |  |
 | bizEcosystemLogicProxy.externalIdp.enabled | bool | `false` | Enable usage of external IDPs |
+| bizEcosystemLogicProxy.externalIdp.showLocalLogin | bool | `false` | Show login button for local IDP on login modal dialog with list of external IDPs |
 | bizEcosystemLogicProxy.fullnameOverride | string | `""` |  |
 | bizEcosystemLogicProxy.ingress.annotations | object | `{}` | annotations to be added to the ingress |
 | bizEcosystemLogicProxy.ingress.enabled | bool | `false` | should there be an ingress to connect the logic proxy with the public internet |

--- a/charts/business-api-ecosystem/README.md
+++ b/charts/business-api-ecosystem/README.md
@@ -117,6 +117,7 @@ A Helm chart for running the FIWARE business API ecosystem (FIWARE Marketplace) 
 | bizEcosystemChargingBackend.token.identifier | string | `""` | Identifier (e.g. EORI) of local marketplace instance |
 | bizEcosystemChargingBackend.token.key | string | `""` | String with private key in PEM format |
 | bizEcosystemChargingBackend.verifyRequests | bool | `true` |  |
+| bizEcosystemLogicProxy.allowLocalEORI | bool | `false` | Allow to use organisations from local IDP as participants when creating or acquiring offerings |
 | bizEcosystemLogicProxy.collectStaticCommand | string | `"True"` | Execute the collect static command on startup |
 | bizEcosystemLogicProxy.db.database | string | `"belp_db"` | Database name for connecting the database |
 | bizEcosystemLogicProxy.db.host | string | `"mongo"` | host of the database to be used |

--- a/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/statefulset.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/statefulset.yaml
@@ -204,6 +204,8 @@ spec:
               value: {{ .Values.bizEcosystemLogicProxy.externalIdp.enabled | quote }}
             - name: BAE_LP_SHOW_LOCAL_LOGIN
               value: {{ .Values.bizEcosystemLogicProxy.externalIdp.showLocalLogin | quote }}
+            - name: BAE_LP_ALLOW_LOCAL_EORI
+              value: {{ .Values.bizEcosystemLogicProxy.allowLocalEORI | quote }}
             - name: BAE_LP_PROPAGATE_TOKEN
               value: {{ .Values.bizEcosystemLogicProxy.propagateToken | quote }}
             {{- if .Values.bizEcosystemLogicProxy.token.enabled }}

--- a/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/statefulset.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/statefulset.yaml
@@ -202,6 +202,8 @@ spec:
               value: {{ .Values.oauth.oidc | quote }}
             - name: BAE_LP_EXT_LOGIN
               value: {{ .Values.bizEcosystemLogicProxy.externalIdp.enabled | quote }}
+            - name: BAE_LP_SHOW_LOCAL_LOGIN
+              value: {{ .Values.bizEcosystemLogicProxy.externalIdp.showLocalLogin | quote }}
             - name: BAE_LP_PROPAGATE_TOKEN
               value: {{ .Values.bizEcosystemLogicProxy.propagateToken | quote }}
             {{- if .Values.bizEcosystemLogicProxy.token.enabled }}

--- a/charts/business-api-ecosystem/values.yaml
+++ b/charts/business-api-ecosystem/values.yaml
@@ -646,6 +646,8 @@ bizEcosystemLogicProxy:
   externalIdp:
     # -- Enable usage of external IDPs
     enabled: false
+    # -- Show login button for local IDP on login modal dialog with list of external IDPs
+    showLocalLogin: false
     
   ## -- Configuration of local key and certificate for validation and generation of tokens
   token:

--- a/charts/business-api-ecosystem/values.yaml
+++ b/charts/business-api-ecosystem/values.yaml
@@ -663,5 +663,8 @@ bizEcosystemLogicProxy:
   # -- Sets wehther the logic proxy should propagate the user access token to the backend components
   propagateToken: true
 
+  # -- Allow to use organisations from local IDP as participants when creating or acquiring offerings
+  allowLocalEORI: false
+
   # -- Default market owner precentage for Revenue Sharing models
   revenueModel: 30


### PR DESCRIPTION
New config option, which allows to show a button for the locally configured IDP on the modal login dialog when external IDPs are enabled.

Plus option to allow usage of EORIs provided by organisations within a local IDP