### PR TITLE
Updated deployment.yaml

### DIFF
--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orion
-version: 0.0.18
+version: 0.0.19
 appVersion: 1.0.1
 home: https://fiware-orion.readthedocs.io/en/master/
 description: A Helm chart for running the fiware orion broker on kubernetes.

--- a/charts/orion/templates/deployment.yaml
+++ b/charts/orion/templates/deployment.yaml
@@ -243,21 +243,33 @@ spec:
             - name: {{ .Values.broker.envPrefix }}DISABLE_METRICS
               value: "FALSE"
             {{- end }}
-            {{ if .Values.broker.metrics.statCountersEnabled  }}
+            {{ if .Values.broker.metrics.statCountersEnabled }}
             - name: {{ .Values.broker.envPrefix }}STAT_COUNTERS
-              value: {{ .Values.broker.metrics.statCountersEnabled | upper }}
+              value: "TRUE"
+            {{ else }}
+            - name: {{ .Values.broker.envPrefix }}STAT_COUNTERS
+              value: "FALSE"
             {{ end }}
             {{ if .Values.broker.metrics.statSemWaitEnabled }}
             - name: {{ .Values.broker.envPrefix }}STAT_SEM_WAIT
-              value: {{ .Values.broker.metrics.statSemWaitEnabled | upper }}
+              value: "TRUE"
+            {{ else }}
+            - name: {{ .Values.broker.envPrefix }}STAT_SEM_WAIT
+              value: "FALSE"
             {{- end }}
             {{ if .Values.broker.metrics.statTimingEnabled }}
             - name: {{ .Values.broker.envPrefix }}STAT_TIMING
-              value: {{ .Values.broker.metrics.statTimingEnabled | upper }}
+              value: "TRUE"
+            {{ else }}
+            - name: {{ .Values.broker.envPrefix }}STAT_TIMING
+              value: "FALSE"            
             {{- end }}
             {{ if .Values.broker.metrics.statNotifQueueEnabled }}
             - name: {{ .Values.broker.envPrefix }}STAT_NOTIF_QUEUE
-              value: {{ .Values.broker.metrics.statNotifQueueEnabled | upper }}
+              value: "TRUE"
+            {{ else }}
+            - name: {{ .Values.broker.envPrefix }}STAT_NOTIF_QUEUE
+              value: "FALSE"               
             {{- end }}
             {{- end }}
 
@@ -348,3 +360,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      


### PR DESCRIPTION
When setting statCountersEnabled, statSemWaitEnabled, statTimingEnabled or statNotifQueueEnabled to true we got the following error since upper could not be applied to a boolean:

Error: UPGRADE FAILED: template: orion/templates/deployment.yaml:252:68: executing "orion/templates/deployment.yaml" at : wrong type for value; expected string; got bool

We fixed it by adding "if" statements and setting the value accordingly.