### PR TITLE
fix version error K8s over 1.19

### DIFF
--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orion
 version: 1.0.1
 appVersion: 1.0.1
-kubeVersion: '>= 1.19'
+kubeVersion: '>= 1.19-0'
 home: https://github.com/FIWARE/context.Orion-LD
 description: A Helm chart for running the fiware orion-ld context broker on kubernetes.
 icon: https://fiware.github.io/catalogue/img/fiware.png


### PR DESCRIPTION
For example, this error:
Error: INSTALLATION FAILED: chart requires kubeVersion: >= 1.19 which is incompatible with Kubernetes v1.21.9-gke.1002