### PR TITLE
Fix keyrock pvc template syntax

### DIFF
--- a/charts/keyrock/Chart.yaml
+++ b/charts/keyrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keyrock
-version: 0.6.1
+version: 0.6.2
 appVersion: 8.3.3
 home: https://fiware-idm.readthedocs.io/en/latest/
 description: A Helm chart for running the fiware idm keyrock on kubernetes.

--- a/charts/keyrock/README.md
+++ b/charts/keyrock/README.md
@@ -1,6 +1,6 @@
 # keyrock
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![AppVersion: 8.3.3](https://img.shields.io/badge/AppVersion-8.3.3-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![AppVersion: 8.3.3](https://img.shields.io/badge/AppVersion-8.3.3-informational?style=flat-square)
 
 A Helm chart for running the fiware idm keyrock on kubernetes.
 

--- a/charts/keyrock/templates/pvc.yaml
+++ b/charts/keyrock/templates/pvc.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   {{- if .Values.certs.pvc.storageClass }}
   storageClassName: {{ .Values.certs.pvc.storageClass }}
-  {{- end -}}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Chomp right breaks the yaml to json

`Error: INSTALLATION FAILED: YAML parse error on keyrock/templates/pvc.yaml: error converting YAML to JSON: yaml: line 12: did not find expected key`