### PR TITLE
Avoid loading the theme from an init container if the url is defined

### DIFF
--- a/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/statefulset.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-logic-proxy/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         {{- include "business-api-ecosystem.initContainer.apis" ( dict "ctx" . "name" "{{ include \"bizEcosystemLogicProxy.apiInitContainer\" . }}-usage" "path" "DSUsageManagement" ) | nindent 8 }}
         {{- include "business-api-ecosystem.initContainer.charging" ( dict "ctx" . "name" "{{ include \"bizEcosystemLogicProxy.apiInitContainer\" . }}-charging" "path" "charging/api/assetManagement/currencyCodes" ) | nindent 8 }}
         {{- end }}
-        {{- if .Values.bizEcosystemLogicProxy.theme.enabled }}
+        {{- if and .Values.bizEcosystemLogicProxy.theme.enabled (not .Values.bizEcosystemLogicProxy.theme.url)}}
         - name: {{ .Values.bizEcosystemLogicProxy.name }}-theme-init
           image: {{ .Values.bizEcosystemLogicProxy.theme.image }}
           imagePullPolicy: {{ .Values.bizEcosystemLogicProxy.theme.imagePullPolicy }}


### PR DESCRIPTION
The BAE proxy theme can be loaded from an external source using the theme.url var. This PR avoid the chart trying to use the init container image when the theme is enabled if the url has been provided