### PR TITLE
Orion.initData process for slow deployment scenarios

### DIFF
--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orion
 version: 1.3.1
 appVersion: 1.0.1
-kubeVersion: ">= 1.19-0"
+kubeVersion: '>= 1.19-0'
 home: https://github.com/FIWARE/context.Orion-LD
 description: A Helm chart for running the fiware orion-ld context broker on kubernetes.
 icon: https://fiware.github.io/catalogue/img/fiware.png

--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: orion
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.0.1
-kubeVersion: '>= 1.19-0'
+kubeVersion: ">= 1.19-0"
 home: https://github.com/FIWARE/context.Orion-LD
 description: A Helm chart for running the fiware orion-ld context broker on kubernetes.
 icon: https://fiware.github.io/catalogue/img/fiware.png

--- a/charts/orion/templates/initdata-cm.yaml
+++ b/charts/orion/templates/initdata-cm.yaml
@@ -5,9 +5,40 @@ metadata:
   name: {{ include "orion.fullname" . }}-init-data-cm
 data:
   entrypoint.sh: |-
-    {{- range $d := .Values.initData.entities }}
-    curl -X POST ${ORION_HOST}:${ORION_PORT}/ngsi-ld/v1/entities --header "Content-Type: application/ld+json" -d @/data/{{ $d.name }}
-    {{- end }}
+    #!/bin/sh    
+    RC=-1
+    TRY=1
+    NFILES_DEPLOYED=0
+    NFILES_WITH_MSG=0
+    NFILES={{ len .Values.initData.entities | default 0 }}
+    while [ $TRY -lt 20 ]; do
+      IDX=0
+{{- range $d := .Values.initData.entities }}
+      IDX=$(( $IDX + 1));
+      echo -e "---\n(Try $TRY.$IDX) Deploying FILE /data/{{ $d.name }}..."
+      RESPONSE=$(curl --silent -X POST ${ORION_HOST}:${ORION_PORT}/ngsi-ld/v1/entities --header "Content-Type: application/ld+json" -d @/data/{{ $d.name }} )
+      RC=$?;
+      if [ "$RC" -eq 0 ]; then 
+        if [ ${#RESPONSE} -ne 0 ]; then
+          NFILES_WITH_MSG=$(( $NFILES_WITH_MSG + 1))
+        fi
+        NFILES_DEPLOYED=$(( $NFILES_DEPLOYED + 1));
+        echo "($NFILES_DEPLOYED/$NFILES) FILE /data/{{ $d.name }} posted with response [$RESPONSE]"
+        if [ "$NFILES" -eq "$NFILES_DEPLOYED" ]; then
+          break;
+        fi
+      else
+        echo "Error in Curl RC=$RC"
+        sleep 1
+      fi
+{{- end }}
+      TRY=$(( $TRY + 1));
+    done
+    echo -e "\n---\n$NFILES_DEPLOYED/$NFILES files posted"
+    if [ $NFILES_WITH_MSG -gt 0 ]; then
+      echo "$NFILES_WITH_MSG/$NFILES with message (review them for potential errors)"
+    fi
+    return $RC
   {{ range $d := .Values.initData.entities }}
   {{ $d.name }}: |
     {{- $d.data | nindent 4 }}

--- a/charts/orion/templates/initdata-cm.yaml
+++ b/charts/orion/templates/initdata-cm.yaml
@@ -11,7 +11,8 @@ data:
     NFILES_DEPLOYED=0
     NFILES_WITH_MSG=0
     NFILES={{ len .Values.initData.entities | default 0 }}
-    while [ $TRY -lt 20 ]; do
+    NTRIES={{ .Values.initData.numberDeploymentTries | default 20 }}
+    while [ $TRY -lt $NTRIES ]; do
       IDX=0
 {{- range $d := .Values.initData.entities }}
       IDX=$(( $IDX + 1));

--- a/charts/orion/templates/post-hook-initdata.yaml
+++ b/charts/orion/templates/post-hook-initdata.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "orion.fullname" . }}-init-data
   annotations:
     "helm.sh/hook": {{ .Values.initData.hook }}
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": {{ .Values.initData.hookDeletePolicy | default "before-hook-creation" }}
     "helm.sh/hook-weight": "1"
 spec:
   backoffLimit: {{ .Values.initData.backoffLimit }}

--- a/charts/orion/values.yaml
+++ b/charts/orion/values.yaml
@@ -314,6 +314,10 @@ initData:
   initEnabled: false
   # -- Annotation value for the Hook
   hook: post-install,post-upgrade
+  # -- Annotation value for the Hook hook-delete-policy.
+  # hook-succeeded removes the job on success, leaving it (and its pods) in case of error for perusal
+  # hookDeletePolicy: before-hook-creation, hook-succeeded
+  hookDeletePolicy: before-hook-creation
   # -- Number of retries before considering a Job as failed
   backoffLimit: 1
   # -- Array of entities to be created

--- a/charts/orion/values.yaml
+++ b/charts/orion/values.yaml
@@ -56,12 +56,12 @@ deployment:
   # -- orion resource requests and limits, we leave the default empty to make that a concious choice by the user.
   # for the autoscaling to make sense, you should configure this.
   # resources:
-  # limits:
-  # cpu: 100m
-  # memory: 128Mi
-  # requests:
-  # cpu: 100m
-  # memory: 128Mi
+    # limits:
+      # cpu: 100m
+      # memory: 128Mi
+    # requests:
+      # cpu: 100m
+      # memory: 128Mi
   # -- selector template
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
@@ -132,25 +132,23 @@ ingress:
   # -- should there be an ingress to connect orion with the public internet
   enabled: false
   # -- annotations to be added to the ingress
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: "ambassador"
     ## example annotations, allowing cert-manager to automatically create tls-certs and forcing everything to use ssl.
     # kubernetes.io/tls-acme: "true"
     # ingress.kubernetes.io/ssl-redirect: "true"
   # -- all hosts to be provided
-  hosts:
-    []
+  hosts: []
     # -- provide a hosts and the paths that should be available
     # - host: localhost
-    # paths:
-    # - /
+      # paths:
+      # - /
   # -- configure the ingress' tls
-  tls:
-    []
+  tls: []
     # - secretName: orion-tls
-    # hosts:
-    # - orion.fiware.org
+      # hosts:
+        # - orion.fiware.org
+
 
 ## orion-broker specific configuration
 # see defaults of the unset values at:
@@ -242,7 +240,7 @@ broker:
     ## to make the traces to standard out formated for humans
     # forHumans: false
     ## log line maximum length
-    # lineMaxSize:
+    # lineMaxSize: 
     ## for those log traces at INFO level that print request and/or response payloads, this is the maximum allowed size for those payloads
     # infoPayloadMaxSize:
 
@@ -255,18 +253,18 @@ broker:
     name: orion
     # -- Database authentication (not needed if MongoDB doesn't use --auth)
     # auth:
-    # --user for connecting mongo
-    # user:
-    # -- password to be used on mongo
-    # password:
-    # -- the MongoDB authentication mechanism to use in the case user and password is set
-    # mech: SCRAM-SHA-1
+      # --user for connecting mongo
+      # user:
+      # -- password to be used on mongo
+      # password:
+      # -- the MongoDB authentication mechanism to use in the case user and password is set
+      # mech: SCRAM-SHA-1
     # -- name of the replicaset
     #replicaSet: rs0
     # -- enable SSL in the connection to MongoDB. needs to correspond with the mongoDB setting
     # sslEnabled: true
     # -- specifies the timeout in milliseconds for connections to the replica set
-    # timeout:
+    # timeout: 
     # -- database connection pool
     # poolSize: 10
     # -- write concern for MongoDB write operations: acknowledged (1) or unacknowledged (0)

--- a/charts/orion/values.yaml
+++ b/charts/orion/values.yaml
@@ -56,12 +56,12 @@ deployment:
   # -- orion resource requests and limits, we leave the default empty to make that a concious choice by the user.
   # for the autoscaling to make sense, you should configure this.
   # resources:
-    # limits:
-      # cpu: 100m
-      # memory: 128Mi
-    # requests:
-      # cpu: 100m
-      # memory: 128Mi
+  # limits:
+  # cpu: 100m
+  # memory: 128Mi
+  # requests:
+  # cpu: 100m
+  # memory: 128Mi
   # -- selector template
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
@@ -132,23 +132,25 @@ ingress:
   # -- should there be an ingress to connect orion with the public internet
   enabled: false
   # -- annotations to be added to the ingress
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: "ambassador"
     ## example annotations, allowing cert-manager to automatically create tls-certs and forcing everything to use ssl.
     # kubernetes.io/tls-acme: "true"
     # ingress.kubernetes.io/ssl-redirect: "true"
   # -- all hosts to be provided
-  hosts: []
+  hosts:
+    []
     # -- provide a hosts and the paths that should be available
     # - host: localhost
-      # paths:
-      # - /
+    # paths:
+    # - /
   # -- configure the ingress' tls
-  tls: []
+  tls:
+    []
     # - secretName: orion-tls
-      # hosts:
-        # - orion.fiware.org
-
+    # hosts:
+    # - orion.fiware.org
 
 ## orion-broker specific configuration
 # see defaults of the unset values at:
@@ -240,7 +242,7 @@ broker:
     ## to make the traces to standard out formated for humans
     # forHumans: false
     ## log line maximum length
-    # lineMaxSize: 
+    # lineMaxSize:
     ## for those log traces at INFO level that print request and/or response payloads, this is the maximum allowed size for those payloads
     # infoPayloadMaxSize:
 
@@ -253,18 +255,18 @@ broker:
     name: orion
     # -- Database authentication (not needed if MongoDB doesn't use --auth)
     # auth:
-      # --user for connecting mongo
-      # user:
-      # -- password to be used on mongo
-      # password:
-      # -- the MongoDB authentication mechanism to use in the case user and password is set
-      # mech: SCRAM-SHA-1
+    # --user for connecting mongo
+    # user:
+    # -- password to be used on mongo
+    # password:
+    # -- the MongoDB authentication mechanism to use in the case user and password is set
+    # mech: SCRAM-SHA-1
     # -- name of the replicaset
     #replicaSet: rs0
     # -- enable SSL in the connection to MongoDB. needs to correspond with the mongoDB setting
     # sslEnabled: true
     # -- specifies the timeout in milliseconds for connections to the replica set
-    # timeout: 
+    # timeout:
     # -- database connection pool
     # poolSize: 10
     # -- write concern for MongoDB write operations: acknowledged (1) or unacknowledged (0)
@@ -320,6 +322,9 @@ initData:
   hookDeletePolicy: before-hook-creation
   # -- Number of retries before considering a Job as failed
   backoffLimit: 1
+  # initData.numberDeploymentTries customizes the number of tries before deployment of initial data fails.
+  # This solves the issue in low resourced k8s environments that some pods can take some time to be fully deployed
+  numberDeploymentTries: 20
   # -- Array of entities to be created
   entities: []
   #  - name: entity001.json


### PR DESCRIPTION
- [charts/orion/templates/initdata-cm.yaml](https://github.com/cgonzalez509/fiware-helm-charts/commit/f5721f2c5216900f350910547e7c06aa09451018#diff-c6c281081a17737cbd60078459719e1a72d9d543041312887b3d48acef2544ee): Changed to make entrypoint.sh retry several times curl post of new entities before failing. In some deployments orion server needs some seconds to be ready
- [charts/orion/templates/post-hook-initdata.yaml](https://github.com/cgonzalez509/fiware-helm-charts/commit/dac8f839c9aca1e3d2ef53ec1763971790aa2541#diff-0f766310becccaaae24433adfa7ac224060319355d3a5eb025e5fae21905faad) & [charts/orion/values.yaml](https://github.com/cgonzalez509/fiware-helm-charts/commit/dac8f839c9aca1e3d2ef53ec1763971790aa2541#diff-69c8bf2066b5d66b2f5448856ac3b1bf1f1b88a9709ce7c8fb7865a17f8d82f6): orion.values.initData.hookDeletePolicy variable added to allow setting custom hook delete policies (def. value is the already existing one: _hookDeletePolicy: before-hook-creation_). eg.  hook-succeded to delete init job on success. Tested on minikube