### PR TITLE
Moved oprion and iot-agent-json autoscaling.apiVersion defaults

### DIFF
--- a/charts/iotagent-json/templates/deployment-hpa.yaml
+++ b/charts/iotagent-json/templates/deployment-hpa.yaml
@@ -1,6 +1,6 @@
 
 {{- if .Values.autoscaling.enabled -}}
-apiVersion: autoscaling/{{ .Values.autoscaling.apiVersion | default "v1" }}
+apiVersion: autoscaling/{{ .Values.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "iota-json.fullname" . }}

--- a/charts/iotagent-json/values.yaml
+++ b/charts/iotagent-json/values.yaml
@@ -102,6 +102,8 @@ deployment:
 autoscaling:
   # -- should autoscaling be enabled
   enabled: false
+  # -- version of the autoscaling API
+  apiVersion: "v1"
   # -- minimum number of running pods
   minReplicas: 1
   # -- maximum number of running pods

--- a/charts/orion/templates/deployment-hpa.yaml
+++ b/charts/orion/templates/deployment-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled -}}
-apiVersion: autoscaling/{{ .Values.autoscaling.apiVersion | default "v2beta2" }}
+apiVersion: autoscaling/{{ .Values.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "orion.fullname" . }}

--- a/charts/orion/values.schema.json
+++ b/charts/orion/values.schema.json
@@ -54,6 +54,7 @@
       },
       "autoscaling": {
         "enabled": false,
+        "apiVersion": "v2beta2",
         "minReplicas": 1,
         "maxReplicas": 10,
         "metrics": []

--- a/charts/orion/values.yaml
+++ b/charts/orion/values.yaml
@@ -92,6 +92,8 @@ deployment:
 autoscaling:
   # -- should autoscaling be enabled for the context broker
   enabled: false
+  # -- version of the autoscaling API
+  apiVersion: "v2beta2"
   # -- minimum number of running pods
   minReplicas: 1
   # -- maximum number of running pods


### PR DESCRIPTION
The defaults for `.Values.autoscaling.apiVersion` of orion and iot-agent deployment-hpa were added direclty into the file instead of tha values file before.
They are now moved directly in the corresponding values file.