### PR TITLE
feat(business-api-ecosystem): allow configuring the key of the password field for connecting to mongo

### DIFF
--- a/charts/business-api-ecosystem/templates/biz-ecosystem-charging-backend/deployment.yaml
+++ b/charts/business-api-ecosystem/templates/biz-ecosystem-charging-backend/deployment.yaml
@@ -148,7 +148,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                    name: {{ include "bizEcosystemChargingBackend.secretName" . }}
-                   key: dbPassword
+                   key: {{ .Values.bizEcosystemChargingBackend.db.secretKey | quote }}
             - name: BAE_LP_OAUTH2_ADMIN_ROLE
               value: {{ .Values.oauth.adminrole | quote }}
             - name: BAE_LP_OAUTH2_SELLER_ROLE

--- a/charts/business-api-ecosystem/values.yaml
+++ b/charts/business-api-ecosystem/values.yaml
@@ -549,6 +549,8 @@ bizEcosystemChargingBackend:
     user: root
     ## -- password for connecting the database
     password: pass
+    # -- key of the password inside the secret
+    secretKey: dbPassword
 
   ## -- Mailing configuration
   email:


### PR DESCRIPTION
Copied the functionality from the already working bizEcosystemLogicProxy configuration.