### PR TITLE
ORION: Configure initContainers through values

### DIFF
--- a/charts/orion/Chart.yaml
+++ b/charts/orion/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: orion
-version: 1.5.0
+version: 1.6.0
 appVersion: 1.0.1
 kubeVersion: '>= 1.19-0'
 home: https://github.com/FIWARE/context.Orion-LD

--- a/charts/orion/templates/deployment.yaml
+++ b/charts/orion/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
       {{- end }}
     spec: 
       serviceAccountName: {{ include "orion.serviceAccountName" . }}
+      {{- if .Values.deployment.initContainers }}
+      initContainers:
+        {{- with .Values.deployment.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}


### PR DESCRIPTION
In order to make orion compatible with the current deployment of scorpio via the umbrella chart of the DSC, something like this should be needed to enable automatic registration of the service in the credentials config service:

```yaml
orion:
  enabled: false
  fullnameOverride: data-service-orion
  service:
    type: ClusterIP
    port: 9090
  ccs:
    endpoint: http://credentials-config-service:8080
    configMap: orion-registration
    id: data-service
  broker:
    db:
      hosts:
        - data-service-mongodb
  deployment:
  ###################################
    initContainers:
      - name: register-credential-config
        image: quay.io/curl/curl:8.1.2
        command: [ "/bin/sh", "-c", "/bin/init.sh" ]
        volumeMounts:
          - name: orion-registration
            mountPath: /bin/init.sh
            subPath: init.sh
  ###################################
    volumes:
      - name: orion-registration
        configMap:
          name: orion-registration
          defaultMode: 0755
```

If this pull request is accepted  another pull request will follow to the DSC umbrella chart repo adding support for orion as an alternative to scorpio. When a new version of this chart is published.