### PR TITLE
feat(vcverifier): add support to mount certificates and CA

### DIFF
--- a/charts/vcverifier/Chart.yaml
+++ b/charts/vcverifier/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vcverifier
-version: 4.7.3
+version: 4.8.0
 appVersion: 6.4.1
 home: https://github.com/fiware/vcverifier
 description: A Helm chart for running the FIWARE VCVerifier.

--- a/charts/vcverifier/Chart.yaml
+++ b/charts/vcverifier/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vcverifier
-version: 4.7.12
+version: 4.8.0
 appVersion: 6.10.2
 home: https://github.com/fiware/vcverifier
 description: A Helm chart for running the FIWARE VCVerifier.

--- a/charts/vcverifier/README.md
+++ b/charts/vcverifier/README.md
@@ -1,6 +1,6 @@
 # vcverifier
 
-![Version: 4.7.3](https://img.shields.io/badge/Version-4.7.3-informational?style=flat-square) ![AppVersion: 6.4.1](https://img.shields.io/badge/AppVersion-6.4.1-informational?style=flat-square)
+![Version: 4.8.0](https://img.shields.io/badge/Version-4.8.0-informational?style=flat-square) ![AppVersion: 6.4.1](https://img.shields.io/badge/AppVersion-6.4.1-informational?style=flat-square)
 
 A Helm chart for running the FIWARE VCVerifier.
 
@@ -56,15 +56,44 @@ A Helm chart for running the FIWARE VCVerifier.
 | deployment.server.port | int | `3000` | port to bind the server to |
 | deployment.server.staticDir | string | `"views/static"` | directory to be used for static content, f.e. images referenced from the templates |
 | deployment.server.templateDir | string | `"views/"` | directory to be used for retrieving the templates. |
+| deployment.serverCertificates | object | `{"caCert":{"bundleImage":{"bundlePath":"/etc/ssl/cert.pem","repository":"alpine","tag":"3.23.3"},"enabled":false,"key":null,"secretName":null},"clientKey":{"privateKey":null,"publicKey":null,"secretName":null},"signingKey":{"key":null,"secretName":null}}` | Configuration for certificates used by the verifier |
+| deployment.serverCertificates.caCert | object | `{"bundleImage":{"bundlePath":"/etc/ssl/cert.pem","repository":"alpine","tag":"3.23.3"},"enabled":false,"key":null,"secretName":null}` | Certificate Authority bundle to add/trust for the application. |
+| deployment.serverCertificates.caCert.bundleImage | object | `{"bundlePath":"/etc/ssl/cert.pem","repository":"alpine","tag":"3.23.3"}` | Container image used to extract base CA bundle. |
+| deployment.serverCertificates.caCert.bundleImage.repository | string | `"alpine"` | Image repository |
+| deployment.serverCertificates.caCert.bundleImage.tag | string | `"3.23.3"` | Image tag to use for the bundle reader image. |
+| deployment.serverCertificates.caCert.key | string | `nil` | Key name inside the Secret containing the CA PEM |
+| deployment.serverCertificates.caCert.secretName | string | `nil` | Kubernetes Secret that contains the CA bundle. |
+| deployment.serverCertificates.clientKey | object | `{"privateKey":null,"publicKey":null,"secretName":null}` | Private key used by the verifier |
+| deployment.serverCertificates.clientKey.privateKey | string | `nil` | key name inside the Secret containing the private key PEM |
+| deployment.serverCertificates.clientKey.publicKey | string | `nil` | key name inside the Secret containing the public key PEM |
+| deployment.serverCertificates.clientKey.secretName | string | `nil` | Name of the Kubernetes Secret that contains the client key. |
+| deployment.serverCertificates.signingKey | object | `{"key":null,"secretName":null}` | Private key used by the verifier to sign credentials. |
+| deployment.serverCertificates.signingKey.key | string | `nil` | Key name inside the Secret containing the PEM |
+| deployment.serverCertificates.signingKey.secretName | string | `nil` | Name of the Kubernetes Secret that contains the signing key. |
 | deployment.tolerations | list | `[]` | tolerations template ref: ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | deployment.updateStrategy.rollingUpdate | object | `{"maxSurge":1,"maxUnavailable":0}` | new pods will be added gradually |
 | deployment.updateStrategy.rollingUpdate.maxSurge | int | `1` | number of pods that can be created above the desired amount while updating |
 | deployment.updateStrategy.rollingUpdate.maxUnavailable | int | `0` | number of pods that can be unavailable while updating |
 | deployment.updateStrategy.type | string | `"RollingUpdate"` | type of the update |
-| deployment.verifier | object | `{"did":"did:key:myverifier","sessionExpiry":30,"tirAddress":"http://my-tir.org","validationMode":"none"}` | configuration required for the verifier functionality |
+| deployment.verifier | object | `{"authorizationEndpoint":null,"clientIdentification":{"certificatePath":null,"id":null,"keyAlgorithm":null,"keyPath":null,"kid":null},"did":"did:key:myverifier","generateKey":true,"jwtExpiration":30,"keyAlgorithm":"RS256","keyPath":null,"policyConfig":{},"sessionExpiry":30,"supportedModes":["urlEncoded"],"tilCacheExpiry":30,"tirAddress":"http://my-tir.org","tirCacheExpiry":30,"validationMode":"none"}` | configuration required for the verifier functionality |
+| deployment.verifier.authorizationEndpoint | string | `nil` | path of the authorizationEndpoint to be provided in the .well-known/openid-configuration |
+| deployment.verifier.clientIdentification | object | `{"certificatePath":null,"id":null,"keyAlgorithm":null,"keyPath":null,"kid":null}` | Identification to be used for the verifier. |
+| deployment.verifier.clientIdentification.certificatePath | string | `nil` | optional path to the certifcate to embed in the jwt header |
+| deployment.verifier.clientIdentification.id | string | `nil` | identification used by the verifier when requesting authorization. Can be a did, but also methods like x509_san_dns |
+| deployment.verifier.clientIdentification.keyAlgorithm | string | `nil` | algorithm used for the request signing key |
+| deployment.verifier.clientIdentification.keyPath | string | `nil` | path to the did signing key(in pem format) for request object mode |
+| deployment.verifier.clientIdentification.kid | string | `nil` | Kid used when key certificate does not include it. If both are missing, id is used |
 | deployment.verifier.did | string | `"did:key:myverifier"` | did to be used for the verifier |
+| deployment.verifier.generateKey | bool | `true` | when set to true, the private key is generated on startup. Its not persisted and just kept in memory. |
+| deployment.verifier.jwtExpiration | int | `30` | expiration time in minutes for JWT tokens |
+| deployment.verifier.keyAlgorithm | string | `"RS256"` | algorithm to be used for the jwt signatures - currently supported: RS256 and ES256 |
+| deployment.verifier.keyPath | string | `nil` | path to the private key for jwt signatures |
+| deployment.verifier.policyConfig | object | `{}` | policies that shall be checked |
 | deployment.verifier.sessionExpiry | int | `30` | expiry of a login-session in seconds |
+| deployment.verifier.supportedModes | list | `["urlEncoded"]` | supported request modes - currently 'urlEncoded', 'byValue' and 'byReference' are available. In case of byValue, the keyPath has to be set. |
+| deployment.verifier.tilCacheExpiry | int | `30` | expiry of the til-cache entries |
 | deployment.verifier.tirAddress | string | `"http://my-tir.org"` | address of the trusted issuers registry to be used for verification |
+| deployment.verifier.tirCacheExpiry | int | `30` | expiry of the tir-cache entries |
 | deployment.verifier.validationMode | string | `"none"` | validation mode for validation the vcs (dont get confused, its just about validation, verfication happens anyways) applicable modes: * `none`: No validation, just swallow everything * `combined`: ld and schema validation * `jsonLd`: uses JSON-LD parser for validation * `baseContext`: validates that only the fields and values (when applicable)are present in the document. No extra fields are allowed (outside of credentialSubject). Default is set to `none` to ensure backwards compatibility |
 | fullnameOverride | string | `""` |  |
 | ingress.annotations | object | `{}` | annotations to be added to the ingress |

--- a/charts/vcverifier/README.md
+++ b/charts/vcverifier/README.md
@@ -1,6 +1,6 @@
 # vcverifier
 
-![Version: 4.7.12](https://img.shields.io/badge/Version-4.7.12-informational?style=flat-square) ![AppVersion: 6.10.2](https://img.shields.io/badge/AppVersion-6.10.2-informational?style=flat-square)
+![Version: 4.8.0](https://img.shields.io/badge/Version-4.8.0-informational?style=flat-square) ![AppVersion: 6.10.2](https://img.shields.io/badge/AppVersion-6.10.2-informational?style=flat-square)
 
 A Helm chart for running the FIWARE VCVerifier.
 

--- a/charts/vcverifier/templates/deployment.yaml
+++ b/charts/vcverifier/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "vcverifier.fullname" . }}
   namespace: {{ $.Release.Namespace | quote }}
   labels:
-    {{ include "vcverifier.labels" . | nindent 4 }}
+    {{- include "vcverifier.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
   revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "vcverifier.labels" . | nindent 8 }}
+        {{- include "vcverifier.labels" . | nindent 8 }}
         {{- with .Values.deployment.additionalLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -29,7 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-    spec: 
+    spec:
       serviceAccountName: {{ include "vcverifier.serviceAccountName" . }}
       {{- if .Values.deployment.hostAliases }}
       hostAliases:
@@ -39,6 +39,19 @@ spec:
       {{- end }}
       {{- if .Values.deployment.initContainers }}
       initContainers:
+        {{- if .Values.deployment.serverCertificates.caCert.enabled}}
+        {{- with .Values.deployment.serverCertificates.caCert }}
+        - name: add-root-ca
+          image: {{ .bundleImage.repository }}:{{ .bundleImage.tag }}
+          command: ["sh", "-c", "cat {{.bundleImage.bundlePath }} /tmp/ca.crt > /root-ca/cert.pem"]
+          volumeMounts:
+            - name: ca-bundle
+              mountPath: /root-ca
+            - name: custom-ca-volume
+              mountPath: /tmp/ca.crt
+              subPath: {{ .key }}
+        {{- end }}
+        {{- end }}
         {{- with .Values.deployment.initContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -87,6 +100,26 @@ spec:
           volumeMounts:
             - mountPath: /configs/
               name: config-volume
+            {{- if and .Values.deployment.serverCertificates.signingKey.secretName .Values.deployment.verifier.keyPath }}
+            - mountPath: {{ .Values.deployment.verifier.keyPath }}
+              name: signing-certs-volume
+              subPath: {{ .Values.deployment.serverCertificates.signingKey.key }}
+            {{- end }}
+            {{- if and .Values.deployment.serverCertificates.clientKey.secretName }}
+            {{- if .Values.deployment.verifier.clientIdentification.keyPath }}
+            - mountPath: {{ .Values.deployment.verifier.clientIdentification.keyPath }}
+              name: certs-volume
+              subPath: {{ .Values.deployment.serverCertificates.clientKey.privateKey }}
+            {{- end }}
+            {{- if .Values.deployment.verifier.clientIdentification.certificatePath }}
+            - mountPath: {{ .Values.deployment.verifier.clientIdentification.certificatePath }}
+              name: certs-volume
+              subPath: {{ .Values.deployment.serverCertificates.clientKey.publicKey }}
+            - name: ca-bundle
+              mountPath: /etc/ssl/cert.pem
+              subPath: cert.pem
+            {{- end }}
+            {{- end }}
             {{- if .Values.templates }}
             - mountPath: /templates/
               name: template-volume
@@ -104,6 +137,23 @@ spec:
       - name: config-volume
         configMap:
           name: {{ include "vcverifier.fullname" . }}
+      {{- if .Values.deployment.serverCertificates.caCert.enabled }}
+      - name: custom-ca-volume
+        secret:
+          secretName: {{ .Values.deployment.serverCertificates.caCert.secretName }}
+      - name: ca-bundle
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.deployment.serverCertificates.signingKey.secretName  }}
+      - name: signing-certs-volume
+        secret:
+          secretName: {{ .Values.deployment.serverCertificates.signingKey.secretName }}
+      {{- end }}
+      {{- if .Values.deployment.serverCertificates.clientKey.secretName  }}
+      - name: certs-volume
+        secret:
+          secretName: {{ .Values.deployment.serverCertificates.clientKey.secretName }}
+      {{- end }}
       {{- if .Values.deployment.additionalVolumes }}
       {{- with .Values.deployment.additionalVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/vcverifier/templates/ingress.yaml
+++ b/charts/vcverifier/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "vcverifier.fullname" . }}
   namespace: {{ $.Release.Namespace | quote }}
   labels:
-    {{ include "vcverifier.labels" . | nindent 4 }}
+    {{- include "vcverifier.labels" . | nindent 4 }}
   {{- if .Values.ingress.annotations }}
   annotations:
     {{- with .Values.ingress.annotations }}
@@ -39,7 +39,7 @@ spec:
           backend:
             service:
               name: {{ $fullName }}
-              port: 
+              port:
                 number: {{ $servicePort }}
         {{- end }}
   {{- end }}

--- a/charts/vcverifier/templates/route.yaml
+++ b/charts/vcverifier/templates/route.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "vcverifier.fullname" . }}
   namespace: {{ $.Release.Namespace | quote }}
   labels:
-    {{ include "vcverifier.labels" . | nindent 4 }}
+    {{- include "vcverifier.labels" . | nindent 4 }}
   {{- if or .Values.route.annotations .Values.route.certificate }}
   annotations:
     {{- if .Values.route.certificate }}

--- a/charts/vcverifier/templates/service.yaml
+++ b/charts/vcverifier/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{ toYaml .Values.service.annotations | nindent 4 }}
   {{- end }}
   labels:
-    {{ include "vcverifier.labels" . | nindent 4 }}
+    {{- include "vcverifier.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/vcverifier/values.yaml
+++ b/charts/vcverifier/values.yaml
@@ -99,6 +99,36 @@ deployment:
   configRepo:
     configEndpoint: http://credentials-config:8080/
 
+  # -- Configuration for certificates used by the verifier
+  serverCertificates:
+    # -- Private key used by the verifier to sign credentials.
+    signingKey:
+      # -- Name of the Kubernetes Secret that contains the signing key.
+      secretName: ''
+      # -- Key name inside the Secret containing the PEM
+      key: ''
+    # -- Private key used by the verifier
+    clientKey:
+      # -- Name of the Kubernetes Secret that contains the client key.
+      secretName: ''
+      # -- key name inside the Secret containing the private key PEM
+      privateKey: ''
+      # -- key name inside the Secret containing the public key PEM
+      publicKey: ''
+    # -- Certificate Authority bundle to add/trust for the application.
+    caCert:
+      enabled: false
+      # -- Container image used to extract base CA bundle.
+      bundleImage:
+        # -- Image repository
+        repository: alpine
+        # -- Image tag to use for the bundle reader image.
+        tag: 3.23.3
+        bundlePath: /etc/ssl/cert.pem
+      # -- Kubernetes Secret that contains the CA bundle.
+      secretName: ''
+      # -- Key name inside the Secret containing the CA PEM
+      key: ''
   # -- additional labels for the deployment, if required
   additionalLabels: {}
   # -- additional annotations for the deployment, if required

--- a/charts/vcverifier/values.yaml
+++ b/charts/vcverifier/values.yaml
@@ -82,10 +82,32 @@ deployment:
   verifier:
     # -- did to be used for the verifier
     did: did:key:myverifier
+    # -- Identification to be used for the verifier.
+    clientIdentification:
+      # -- path to the did signing key(in pem format) for request object mode
+      keyPath:
+      # -- algorithm used for the request signing key
+      keyAlgorithm:
+      # -- identification used by the verifier when requesting authorization. Can be a did, but also methods like x509_san_dns
+      id:
+      # -- optional path to the certifcate to embed in the jwt header
+      certificatePath:
+      # -- Kid used when key certificate does not include it. If both are missing, id is used
+      kid:
+    # -- supported request modes - currently 'urlEncoded', 'byValue' and 'byReference' are available. In case of byValue, the keyPath has to be set.
+    supportedModes: ["urlEncoded"]
     # -- address of the trusted issuers registry to be used for verification
     tirAddress: http://my-tir.org
+    # -- expiry of the tir-cache entries
+    tirCacheExpiry: 30
+    # -- expiry of the til-cache entries
+    tilCacheExpiry: 30
     # -- expiry of a login-session in seconds
     sessionExpiry: 30
+    # -- policies that shall be checked
+    policyConfig: {}
+    # -- path of the authorizationEndpoint to be provided in the .well-known/openid-configuration
+    authorizationEndpoint:
     # -- validation mode for validation the vcs (dont get confused, its just about validation, verfication happens anyways)
     # applicable modes:
     # * `none`: No validation, just swallow everything
@@ -94,6 +116,14 @@ deployment:
     # * `baseContext`: validates that only the fields and values (when applicable)are present in the document. No extra fields are allowed (outside of credentialSubject).
     # Default is set to `none` to ensure backwards compatibility
     validationMode: none
+    # -- algorithm to be used for the jwt signatures - currently supported: RS256 and ES256
+    keyAlgorithm: RS256
+    # -- when set to true, the private key is generated on startup. Its not persisted and just kept in memory.
+    generateKey: true
+    # -- path to the private key for jwt signatures
+    keyPath:
+    # -- expiration time in minutes for JWT tokens
+    jwtExpiration: 30
   else: {}
   # -- config repo configuration
   configRepo:
@@ -104,17 +134,17 @@ deployment:
     # -- Private key used by the verifier to sign credentials.
     signingKey:
       # -- Name of the Kubernetes Secret that contains the signing key.
-      secretName: ''
+      secretName:
       # -- Key name inside the Secret containing the PEM
-      key: ''
+      key:
     # -- Private key used by the verifier
     clientKey:
       # -- Name of the Kubernetes Secret that contains the client key.
-      secretName: ''
+      secretName:
       # -- key name inside the Secret containing the private key PEM
-      privateKey: ''
+      privateKey:
       # -- key name inside the Secret containing the public key PEM
-      publicKey: ''
+      publicKey:
     # -- Certificate Authority bundle to add/trust for the application.
     caCert:
       enabled: false
@@ -126,9 +156,9 @@ deployment:
         tag: 3.23.3
         bundlePath: /etc/ssl/cert.pem
       # -- Kubernetes Secret that contains the CA bundle.
-      secretName: ''
+      secretName:
       # -- Key name inside the Secret containing the CA PEM
-      key: ''
+      key:
   # -- additional labels for the deployment, if required
   additionalLabels: {}
   # -- additional annotations for the deployment, if required


### PR DESCRIPTION
Add properties to mount client and signing certificates.
Additionally, add support for loading a CA. This simplifies usage by eliminating the need for `extraVolumes`, `extraVolumeMounts`, and `initContainers`, which can cause conflicts since they are not extensible.