### PR TITLE
feat(coraine): add helm chart for the coraine NGSI-LD broker

### DIFF
--- a/.github/workflows/check-chart-updates.yml
+++ b/.github/workflows/check-chart-updates.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         chart:
           - contract-management
+          - coraine
           - credentials-config-service
           - did-helper
           - dss-validation-service

--- a/charts/coraine/Chart.yaml
+++ b/charts/coraine/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: coraine
 description: A Helm chart for running the SEAMWARE Coraine NGSI-LD context broker on kubernetes.
 type: application
-version: 0.1.0
+version: 0.1.1
 # Coraine has no semver releases upstream (only `latest` / git-sha image
 # tags), so `latest` is the closest match. Pin `image.tag` explicitly for
 # reproducible deployments.

--- a/charts/coraine/Chart.yaml
+++ b/charts/coraine/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: coraine
+description: A Helm chart for running the SEAMWARE Coraine NGSI-LD context broker on kubernetes.
+type: application
+version: 0.1.0
+# Coraine has no semver releases upstream (only `latest` / git-sha image
+# tags), so `latest` is the closest match. Pin `image.tag` explicitly for
+# reproducible deployments.
+appVersion: "latest"
+icon: https://fiware.github.io/catalogue/img/fiware.png
+keywords:
+  - fiware
+  - coraine
+  - ngsi-ld
+  - context-broker
+sources:
+  - https://github.com/SEAMWARE/coraine
+maintainers:
+  - name: Miguel Ortega Moreno
+    email: miguel.ortega@seamware.com
+# The `common` library chart ships every shared helper
+# (names, labels, service-account resolution, existing-secret
+# resolution, service/ingress/route/HPA/secret/serviceaccount
+# bodies). It is consumed via a local `file://` dependency so
+# publishing workflows do not need a separate repository entry —
+# Helm packages the library alongside coraine in the resulting
+# `coraine-<version>.tgz`. See charts/common/README.md.
+dependencies:
+  - name: common
+    repository: "https://fiware.github.io/helm-charts"
+    version: "0.1.2"

--- a/charts/coraine/README.md
+++ b/charts/coraine/README.md
@@ -1,6 +1,6 @@
 # coraine
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for running the SEAMWARE Coraine NGSI-LD context broker on kubernetes.
 

--- a/charts/coraine/README.md
+++ b/charts/coraine/README.md
@@ -1,0 +1,131 @@
+# coraine
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+
+A Helm chart for running the SEAMWARE Coraine NGSI-LD context broker on kubernetes.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Miguel Ortega Moreno | <miguel.ortega@seamware.com> |  |
+
+## Source Code
+
+* <https://github.com/SEAMWARE/coraine>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://fiware.github.io/helm-charts | common | 0.1.2 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| apiPlugins.admin.enabled | bool | `true` | load the admin/ops API plugin (--apiPlugins admin). Required for /metrics, /admin/tenants, /admin/plugins, /admin/log, etc. The k8s Service always exposes these cluster-internally when enabled; see `ingress.exposeAdminPaths` to also expose them externally. |
+| autoscaling.apiVersion | string | `"v2"` | apiVersion of the HorizontalPodAutoscaler resource |
+| autoscaling.enabled | bool | `false` | should autoscaling be enabled for coraine |
+| autoscaling.maxReplicas | int | `10` | maximum number of running pods |
+| autoscaling.metrics | list | `[]` | list of MetricSpecs to decide whether to scale |
+| autoscaling.minReplicas | int | `1` | minimum number of running pods |
+| config.asyncSnapshot | bool | `false` | run snapshot queries in a background thread (--asyncSnapshot) |
+| config.connectionPoolSize | int | `32` | libmicrohttpd connection pool size (--connectionPoolSize) |
+| config.cooldownMillis | int | `30000` | default endpoint cooldown in ms after a failed notify/forward (--cooldownMillis) |
+| config.cors.enabled | bool | `false` | enable CORS by setting an allowed origin (--corsOrigin). Use "__ALL" to allow any origin. |
+| config.cors.maxAge | int | `86400` | seconds a CORS preflight response may be cached (--corsMaxAge) |
+| config.cors.origin | string | `"__ALL"` | allowed origin, or "__ALL" for any origin |
+| config.defaultUserContext | string | `""` | default @context URL to use when a request supplies none (--defaultUserContext) |
+| config.distOpTimeout | int | `5000` | HTTP client timeout in ms for distributed ops / notifications / context downloads (--distOpTimeout) |
+| config.highPrecision | bool | `false` | use nanosecond (9-digit) timestamps instead of microsecond (6-digit) ones (--high-precision) |
+| config.insecureNotif | bool | `false` | accept self-signed TLS certs on outbound notifications/forwards (--insecureNotif) |
+| config.maxRequestSize | int | `2` | maximum accepted request body size in MiB, 0 = uncapped (--maxRequestSize) |
+| config.notifyValueChangeOnly | bool | `false` | suppress notifications whose payload did not actually change (--notifyValueChangeOnly) |
+| config.port | int | `1026` | port coraine listens on (also used as the container port and default probe port) |
+| config.prettyPrint | bool | `false` | indent JSON responses (--pretty-print) |
+| config.subStatsFlushInterval | int | `60` | seconds between periodic subscription-stats flushes, 0 = disabled (--subStatsFlushInterval) |
+| config.traceLevels | string | `""` | trace level string, e.g. "1-10" (--traceLevels) |
+| database.mongoc.auth.enabled | bool | `false` |  |
+| database.mongoc.auth.existingSecret | object | `{}` | reference an existing secret instead of `password` above. existingSecret:   name: coraine-db-credentials   key: dbPassword |
+| database.mongoc.auth.password | string | `""` | mongo password (--dbPwd), ignored when existingSecret is set. Passed to coraine via an env var + `$(...)` substitution so it is not baked in plaintext into the pod's args spec -- note this is still visible in `ps`/`/proc` inside the container, coraine has no other way to receive it. |
+| database.mongoc.auth.user | string | `""` | mongo username (--dbUser) |
+| database.mongoc.globalDb | string | `"coraine"` | reserved mongo database for global/non-tenant state, e.g. cached JSON-LD contexts (--globalDb) |
+| database.mongoc.host | string | `"mongodb"` | mongo host (--dbHost) |
+| database.mongoc.name | string | `"cor"` | mongo database name (--dbName) |
+| database.mongoc.port | int | `27017` | mongo port (--dbPort) |
+| database.mongoc.timeout | int | `30` | mongo connection timeout in seconds (--dbTimeout) |
+| database.mongoc.uri.enabled | bool | `false` | use a full mongo connection URI instead of host/port/user/pwd (--dbURI). Overrides all other mongoc.* settings above when enabled. |
+| database.mongoc.uri.existingSecret | object | `{}` | reference an existing secret instead of `value` above. existingSecret:   name: coraine-db-credentials   key: dbURI |
+| database.mongoc.uri.value | string | `""` | the connection URI, ignored when existingSecret is set |
+| database.type | string | `"mongo"` | database plugin to load: "mongo" (alias for "mongoc") or "memory" (alias for "corRamDB"). The upstream plugin names "mongoc"/"corRamDB" also work directly; any other value is rejected -- see the note on dynamic plugin loading above. |
+| distributed.contextSourceExtras | object | `{"content":{},"enabled":false}` | render a custom JSON document at /ngsi-ld/v1/info/sourceIdentity (--contextSourceExtras) |
+| distributed.contextSourceExtras.content | object | `{}` | arbitrary JSON content rendered verbatim at /ngsi-ld/v1/info/sourceIdentity |
+| distributed.csourceAlias | string | `""` | identity used for federation loop detection, derived from httpEndpoint when empty (--csourceAlias) |
+| distributed.enabled | bool | `false` | enable forwarding requests to registered Context Sources (--distributed) |
+| distributed.httpEndpoint | string | `""` | this broker's externally-reachable base URL, embedded in Link headers/callbacks (--httpEndpoint). Leave empty to fall back to coraine's own auto-detection (which picks a pod-internal address and is almost never what you want in kubernetes) -- set it explicitly, e.g. "http://<release>-coraine.<namespace>.svc.cluster.local:1026" or your public ingress URL. |
+| distributed.noSplitEntities | bool | `false` | disable splitting a single entity's attributes across multiple sources (--noSplitEntities) |
+| extraArgs | list | `[]` | extra command-line flags appended verbatim after the ones generated from `config`/ `database`/`troe`/etc above, for coraine options this chart does not (yet) model directly |
+| extraEnvVars | list | `[]` | additional environment variables to set on the coraine container ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ |
+| extraEnvVarsSecret | string | `""` | name of an existing Secret to load as additional environment variables (envFrom) |
+| extraManifests | list | `[]` | additional Kubernetes manifests to render alongside this chart's own resources. Each entry is rendered with `tpl`, so it may reference `.Release`, `.Values`, etc. |
+| extraVolumeMounts | list | `[]` | additional volumeMounts on the coraine container |
+| extraVolumes | list | `[]` | additional volumes on the coraine pod |
+| fullnameOverride | string | `""` | option to override the fullname config in the _helpers.tpl |
+| ha.enabled | bool | `false` | enable multi-replica cache sync via MongoDB change streams (--ha mongo) |
+| image.pullPolicy | string | `"IfNotPresent"` | specification of the image pull policy |
+| image.repository | string | `"quay.io/seamware/coraine"` | coraine image name ref: https://quay.io/repository/seamware/coraine |
+| image.tag | string | `""` | tag of the image to be used, defaults to the chart's appVersion ("latest") when empty. Coraine ships no semver releases upstream (only `latest` or a git-sha tag) -- pin a git-sha tag here for reproducible deployments. |
+| imagePullSecrets | list | `[]` | secrets to use for pulling the (private) coraine image ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| ingress.annotations | object | `{}` | annotations to be added to the ingress |
+| ingress.className | string | `""` | ingress class to use |
+| ingress.enabled | bool | `false` | should there be an ingress to connect coraine with the public internet |
+| ingress.exposeAdminPaths | bool | `false` | ADVANCED / SECURITY-SENSITIVE: also route `/admin` and `/metrics` through this ingress, for every host in `hosts` above. These paths let a caller read tenant names, broker version/plugin info and mutate log verbosity at runtime (see coraine's admin plugin docs) -- keep this false unless the ingress itself is otherwise access-controlled (auth annotations, allow-list, mTLS, ...). |
+| ingress.hosts | list | `[]` | all hosts to be provided |
+| ingress.tls | list | `[]` | configure the ingress' tls |
+| livenessProbe.failureThreshold | int | `3` |  |
+| livenessProbe.httpGet.path | string | `"/ngsi-ld/v1/types"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.initialDelaySeconds | int | `10` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| metrics.enabled | bool | `false` | add prometheus.io/scrape annotations to the pod (served at /metrics by the admin plugin) |
+| nameOverride | string | `""` | option to override the name config in the _helpers.tpl |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` | additional annotations for the pod |
+| podLabels | object | `{}` | additional labels for the pod |
+| podSecurityContext | object | `{}` | pod-level security context |
+| readinessProbe.failureThreshold | int | `3` |  |
+| readinessProbe.httpGet.path | string | `"/ngsi-ld/v1/types"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe.initialDelaySeconds | int | `5` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `5` |  |
+| replicaCount | int | `1` | number of coraine replicas. Only combine with `ha.enabled` when running against a shared MongoDB replica set -- otherwise each replica has its own inconsistent state. |
+| resources | object | `{}` | resource requests/limits for the coraine container. Left empty so that setting them (e.g. for autoscaling) is a conscious choice by the user. |
+| route.annotations | object | `{}` | annotations to be added to the route |
+| route.enabled | bool | `false` | should the deployment create an openshift route |
+| route.tls | object | `{}` | tls configuration for the route |
+| securityContext | object | `{}` | container-level security context |
+| service.annotations | object | `{}` | additional annotations, if required |
+| service.port | int | `1026` | port to be used by the service |
+| service.type | string | `"ClusterIP"` | service type |
+| serviceAccount | object | `{"annotations":{},"create":false,"name":""}` | if a coraine specific service account should be used, it can be configured here |
+| serviceAccount.annotations | object | `{}` | additional annotations for the service account |
+| serviceAccount.create | bool | `false` | specifies if the account should be created |
+| serviceAccount.name | string | `""` | name of the service account to use, defaults to the fullname template when create is true |
+| tolerations | list | `[]` |  |
+| troe.timescale.existingSecret | object | `{}` | reference an existing secret instead of `password` above. existingSecret:   name: coraine-troe-credentials   key: troePassword |
+| troe.timescale.host | string | `"timescaledb"` | timescale/postgres host (--troeHost) |
+| troe.timescale.instanceCap | int | `1000000` | max number of temporal instances kept in memory before eviction (--troeInstanceCap) |
+| troe.timescale.name | string | `"corh"` | timescale/postgres database name (--troeName) |
+| troe.timescale.password | string | `""` | timescale/postgres password (--troePwd), ignored when existingSecret is set. Same `$(...)` env-var substitution caveat as database.mongoc.auth.password applies. |
+| troe.timescale.poolSize | int | `10` | connection pool size (--troePoolSize) |
+| troe.timescale.port | int | `5432` | timescale/postgres port (--troePort) |
+| troe.timescale.user | string | `"postgres"` | timescale/postgres user (--troeUser) |
+| troe.type | string | `"none"` | temporal history plugin to load: "none", "ramdb" or "timescale" |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/coraine/templates/NOTES.txt
+++ b/charts/coraine/templates/NOTES.txt
@@ -1,0 +1,16 @@
+Successfully deployed coraine.
+
+Connect at {{ include "coraine.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}
+
+{{- if and .Values.apiPlugins.admin.enabled .Values.ingress.enabled .Values.ingress.exposeAdminPaths }}
+
+WARNING: ingress.exposeAdminPaths is true -- coraine's /admin and /metrics endpoints are
+reachable from outside the cluster on every host configured under ingress.hosts. Make sure
+the ingress itself is access-controlled (auth, allow-list, mTLS, ...).
+{{- end }}
+{{- if and .Values.distributed.enabled (not .Values.distributed.httpEndpoint) }}
+
+WARNING: distributed.enabled is true but distributed.httpEndpoint is empty -- coraine will
+auto-detect a base URL, which is usually a pod-internal address and not reachable by other
+Context Sources. Set distributed.httpEndpoint explicitly.
+{{- end }}

--- a/charts/coraine/templates/_helpers.tpl
+++ b/charts/coraine/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+coraine-specific helpers.
+
+Every helper in this file is a thin wrapper around the matching
+`fiwareCommon.*` helper from the `common` library chart (see
+charts/common/templates/*.tpl), following the same convention as
+charts/orion, charts/mintaka and charts/did-helper.
+*/}}
+
+{{/*
+Expand the name of the chart. Delegates to `fiwareCommon.names.name`.
+*/}}
+{{- define "coraine.name" -}}
+{{- include "fiwareCommon.names.name" . -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name. Delegates to
+`fiwareCommon.names.fullname`.
+*/}}
+{{- define "coraine.fullname" -}}
+{{- include "fiwareCommon.names.fullname" . -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label. Delegates to
+`fiwareCommon.names.chart`.
+*/}}
+{{- define "coraine.chart" -}}
+{{- include "fiwareCommon.names.chart" . -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use. Delegates to
+`fiwareCommon.serviceAccount.name`.
+*/}}
+{{- define "coraine.serviceAccountName" -}}
+{{- include "fiwareCommon.serviceAccount.name" . -}}
+{{- end -}}
+
+{{/*
+Common labels. Delegates to `fiwareCommon.labels.standard`.
+*/}}
+{{- define "coraine.labels" -}}
+{{- include "fiwareCommon.labels.standard" . -}}
+{{- end -}}
+
+{{/*
+Selector labels. Delegates to `fiwareCommon.labels.matchLabels`.
+*/}}
+{{- define "coraine.selectorLabels" -}}
+{{- include "fiwareCommon.labels.matchLabels" . -}}
+{{- end -}}

--- a/charts/coraine/templates/configmap.yaml
+++ b/charts/coraine/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.distributed.contextSourceExtras.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "coraine.fullname" . }}-context-source-extras
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "coraine.labels" . | nindent 4 }}
+data:
+  contextSourceExtras.json: |
+    {{- toJson .Values.distributed.contextSourceExtras.content | nindent 4 }}
+{{- end }}

--- a/charts/coraine/templates/deployment-hpa.yaml
+++ b/charts/coraine/templates/deployment-hpa.yaml
@@ -1,0 +1,3 @@
+{{- include "fiwareCommon.hpa.tpl" (dict
+      "context"     $
+      "autoscaling" .Values.autoscaling) }}

--- a/charts/coraine/templates/deployment.yaml
+++ b/charts/coraine/templates/deployment.yaml
@@ -1,0 +1,258 @@
+{{- $dbAliases := dict "mongo" "mongoc" "memory" "corRamDB" -}}
+{{- $dbType := default .Values.database.type (index $dbAliases .Values.database.type) -}}
+{{- $needsDbURIEnv := and (eq $dbType "mongoc") .Values.database.mongoc.uri.enabled -}}
+{{- $needsDbPwdEnv := and (eq $dbType "mongoc") (not .Values.database.mongoc.uri.enabled) .Values.database.mongoc.auth.enabled -}}
+{{- $needsTroePwdEnv := eq .Values.troe.type "timescale" -}}
+{{- $hasEnv := or $needsDbURIEnv $needsDbPwdEnv $needsTroePwdEnv .Values.extraEnvVars -}}
+{{- $allowedDatabases := list "mongoc" "corRamDB" -}}
+{{- if not (has $dbType $allowedDatabases) }}
+{{- fail (printf "coraine: database.type %q is not a plugin bundled with the image (allowed: %s, or the aliases mongo/memory). Dynamic loading of third-party/custom plugins is intentionally not supported by this chart." .Values.database.type (join ", " $allowedDatabases)) }}
+{{- end }}
+{{- $allowedTroe := list "none" "ramdb" "timescale" -}}
+{{- if not (has .Values.troe.type $allowedTroe) }}
+{{- fail (printf "coraine: troe.type %q is not a plugin bundled with the image (allowed: %s). Dynamic loading of third-party/custom plugins is intentionally not supported by this chart." .Values.troe.type (join ", " $allowedTroe)) }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "coraine.fullname" . }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "coraine.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "coraine.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "coraine.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or (and .Values.apiPlugins.admin.enabled .Values.metrics.enabled) .Values.podAnnotations }}
+      annotations:
+        {{- if and .Values.apiPlugins.admin.enabled .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.config.port | int64 | quote }}
+        prometheus.io/path: "/metrics"
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "coraine.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          args:
+            - "--port"
+            - {{ .Values.config.port | int64 | quote }}
+            - "--connectionPoolSize"
+            - {{ .Values.config.connectionPoolSize | int64 | quote }}
+            - "--maxRequestSize"
+            - {{ .Values.config.maxRequestSize | int64 | quote }}
+            - "--subStatsFlushInterval"
+            - {{ .Values.config.subStatsFlushInterval | int64 | quote }}
+            - "--distOpTimeout"
+            - {{ .Values.config.distOpTimeout | int64 | quote }}
+            - "--cooldownMillis"
+            - {{ .Values.config.cooldownMillis | int64 | quote }}
+            {{- if .Values.config.prettyPrint }}
+            - "--pretty-print"
+            - "1"
+            {{- end }}
+            {{- if .Values.config.notifyValueChangeOnly }}
+            - "--notifyValueChangeOnly"
+            {{- end }}
+            {{- if .Values.config.highPrecision }}
+            - "--high-precision"
+            {{- end }}
+            {{- if .Values.config.asyncSnapshot }}
+            - "--asyncSnapshot"
+            {{- end }}
+            {{- if .Values.config.insecureNotif }}
+            - "--insecureNotif"
+            {{- end }}
+            {{- with .Values.config.defaultUserContext }}
+            - "--defaultUserContext"
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.config.traceLevels }}
+            - "--traceLevels"
+            - {{ . | quote }}
+            {{- end }}
+            {{- if .Values.config.cors.enabled }}
+            - "--corsOrigin"
+            - {{ .Values.config.cors.origin | quote }}
+            - "--corsMaxAge"
+            - {{ .Values.config.cors.maxAge | int64 | quote }}
+            {{- end }}
+            {{- if .Values.distributed.enabled }}
+            - "--distributed"
+            {{- with .Values.distributed.httpEndpoint }}
+            - "--httpEndpoint"
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.distributed.csourceAlias }}
+            - "--csourceAlias"
+            - {{ . | quote }}
+            {{- end }}
+            {{- if .Values.distributed.noSplitEntities }}
+            - "--noSplitEntities"
+            {{- end }}
+            {{- end }}
+            {{- if .Values.distributed.contextSourceExtras.enabled }}
+            - "--contextSourceExtras"
+            - "/etc/coraine/contextSourceExtras.json"
+            {{- end }}
+            - "--database"
+            - {{ $dbType | quote }}
+            {{- if eq $dbType "mongoc" }}
+            - "--dbHost"
+            - {{ .Values.database.mongoc.host | quote }}
+            - "--dbPort"
+            - {{ .Values.database.mongoc.port | int64 | quote }}
+            - "--dbName"
+            - {{ .Values.database.mongoc.name | quote }}
+            - "--globalDb"
+            - {{ .Values.database.mongoc.globalDb | quote }}
+            - "--dbTimeout"
+            - {{ .Values.database.mongoc.timeout | int64 | quote }}
+            {{- if .Values.database.mongoc.uri.enabled }}
+            - "--dbURI"
+            - "$(CORAINE_DB_URI)"
+            {{- else if .Values.database.mongoc.auth.enabled }}
+            - "--dbUser"
+            - {{ .Values.database.mongoc.auth.user | quote }}
+            - "--dbPwd"
+            - "$(CORAINE_DB_PWD)"
+            {{- end }}
+            {{- end }}
+            - "--troe"
+            - {{ .Values.troe.type | quote }}
+            {{- if eq .Values.troe.type "timescale" }}
+            - "--troeHost"
+            - {{ .Values.troe.timescale.host | quote }}
+            - "--troePort"
+            - {{ .Values.troe.timescale.port | int64 | quote }}
+            - "--troeName"
+            - {{ .Values.troe.timescale.name | quote }}
+            - "--troeUser"
+            - {{ .Values.troe.timescale.user | quote }}
+            - "--troePwd"
+            - "$(CORAINE_TROE_PWD)"
+            - "--troePoolSize"
+            - {{ .Values.troe.timescale.poolSize | int64 | quote }}
+            - "--troeInstanceCap"
+            - {{ .Values.troe.timescale.instanceCap | int64 | quote }}
+            {{- end }}
+            {{- if .Values.ha.enabled }}
+            - "--ha"
+            - "mongo"
+            {{- end }}
+            {{- if .Values.apiPlugins.admin.enabled }}
+            - "--apiPlugins"
+            - "admin"
+            {{- end }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if $hasEnv }}
+          env:
+            {{- if $needsDbURIEnv }}
+            - name: CORAINE_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fiwareCommon.secrets.name" (dict "context" $ "existingSecret" .Values.database.mongoc.uri.existingSecret) }}
+                  key: {{ include "fiwareCommon.secrets.key" (dict "context" $ "existingSecret" .Values.database.mongoc.uri.existingSecret "defaultKey" "dbURI") }}
+            {{- else if $needsDbPwdEnv }}
+            - name: CORAINE_DB_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fiwareCommon.secrets.name" (dict "context" $ "existingSecret" .Values.database.mongoc.auth.existingSecret) }}
+                  key: {{ include "fiwareCommon.secrets.key" (dict "context" $ "existingSecret" .Values.database.mongoc.auth.existingSecret "defaultKey" "dbPassword") }}
+            {{- end }}
+            {{- if $needsTroePwdEnv }}
+            - name: CORAINE_TROE_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fiwareCommon.secrets.name" (dict "context" $ "existingSecret" .Values.troe.timescale.existingSecret) }}
+                  key: {{ include "fiwareCommon.secrets.key" (dict "context" $ "existingSecret" .Values.troe.timescale.existingSecret "defaultKey" "troePassword") }}
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.extraEnvVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ tpl .Values.extraEnvVarsSecret . | quote }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.extraVolumeMounts .Values.distributed.contextSourceExtras.enabled }}
+          volumeMounts:
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.distributed.contextSourceExtras.enabled }}
+            - name: context-source-extras
+              mountPath: /etc/coraine
+              readOnly: true
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.extraVolumes .Values.distributed.contextSourceExtras.enabled }}
+      volumes:
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.distributed.contextSourceExtras.enabled }}
+        - name: context-source-extras
+          configMap:
+            name: {{ include "coraine.fullname" . }}-context-source-extras
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/coraine/templates/extra-manifests.yaml
+++ b/charts/coraine/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/coraine/templates/ingress.yaml
+++ b/charts/coraine/templates/ingress.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "coraine.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "coraine.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- range . }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "coraine.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+          {{- if $.Values.ingress.exposeAdminPaths }}
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "coraine.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          - path: /metrics
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "coraine.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/coraine/templates/route.yaml
+++ b/charts/coraine/templates/route.yaml
@@ -1,0 +1,3 @@
+{{- include "fiwareCommon.route.tpl" (dict
+      "context" $
+      "route"   .Values.route) }}

--- a/charts/coraine/templates/secret.yaml
+++ b/charts/coraine/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{/*
+Auto-generated Secret holding the credentials coraine needs, for whichever of
+database.mongoc.auth / database.mongoc.uri / troe.timescale the deployment actually uses --
+skipped (per field) whenever the corresponding `existingSecret` is set instead.
+*/}}
+{{- $data := dict -}}
+{{- if eq .Values.database.type "mongoc" -}}
+  {{- if .Values.database.mongoc.uri.enabled -}}
+    {{- if not (and (kindIs "map" .Values.database.mongoc.uri.existingSecret) .Values.database.mongoc.uri.existingSecret.name) -}}
+      {{- $data = merge $data (dict "dbURI" .Values.database.mongoc.uri.value) -}}
+    {{- end -}}
+  {{- else if .Values.database.mongoc.auth.enabled -}}
+    {{- if not (and (kindIs "map" .Values.database.mongoc.auth.existingSecret) .Values.database.mongoc.auth.existingSecret.name) -}}
+      {{- $data = merge $data (dict "dbPassword" .Values.database.mongoc.auth.password) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq .Values.troe.type "timescale" -}}
+  {{- if not (and (kindIs "map" .Values.troe.timescale.existingSecret) .Values.troe.timescale.existingSecret.name) -}}
+    {{- $data = merge $data (dict "troePassword" .Values.troe.timescale.password) -}}
+  {{- end -}}
+{{- end -}}
+{{- if $data }}
+{{- include "fiwareCommon.secret.tpl" (dict "context" $ "data" $data) }}
+{{- end }}

--- a/charts/coraine/templates/service.yaml
+++ b/charts/coraine/templates/service.yaml
@@ -1,0 +1,6 @@
+{{- include "fiwareCommon.service.tpl" (dict
+      "context" $
+      "service" .Values.service
+      "ports"   (list (dict
+                        "port"       .Values.service.port
+                        "targetPort" "http"))) }}

--- a/charts/coraine/templates/serviceaccount.yaml
+++ b/charts/coraine/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{- include "fiwareCommon.serviceAccount.tpl" (dict "context" $) }}

--- a/charts/coraine/values.schema.json
+++ b/charts/coraine/values.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://fiware.github.io/helm-charts/coraine/values.schema.json",
+  "title": "coraine",
+  "description": "Values schema for the coraine chart. Only fields with a real constraint (enums, numeric ranges) are declared -- everything else is left unconstrained so the many optional toggles in values.yaml (and the extraEnvVars/extraVolumes/extraManifests escape hatches) don't have to be duplicated here.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "exposeAdminPaths": { "type": "boolean" }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "tls": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "termination": {
+              "type": "string",
+              "enum": ["edge", "passthrough", "reencrypt"]
+            }
+          }
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": {
+          "type": "string",
+          "enum": ["v1", "v2beta1", "v2beta2", "v2"]
+        },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "connectionPoolSize": { "type": "integer", "minimum": 1 },
+        "maxRequestSize": { "type": "integer", "minimum": 0 },
+        "subStatsFlushInterval": { "type": "integer", "minimum": 0 },
+        "distOpTimeout": { "type": "integer", "minimum": 0 },
+        "cooldownMillis": { "type": "integer", "minimum": 0 },
+        "cors": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "maxAge": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "distributed": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "noSplitEntities": { "type": "boolean" }
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "\"mongo\"/\"memory\" are chart-level aliases for the upstream plugin names \"mongoc\"/\"corRamDB\", which also work directly. Any other value is rejected at render time -- dynamic loading of custom plugins is intentionally not supported.",
+          "enum": ["mongo", "mongoc", "memory", "corRamDB"]
+        },
+        "mongoc": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "timeout": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "troe": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["none", "ramdb", "timescale"]
+        },
+        "timescale": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "poolSize": { "type": "integer", "minimum": 1 },
+            "instanceCap": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "ha": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "apiPlugins": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "admin": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/charts/coraine/values.yaml
+++ b/charts/coraine/values.yaml
@@ -1,0 +1,358 @@
+## Default values for coraine.
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+##
+## Coraine (https://github.com/SEAMWARE/coraine) is a lightweight NGSI-LD
+## context broker configured entirely through CLI flags (there is no
+## env-var based configuration in the broker itself). This chart turns
+## every upstream flag into a `values.yaml` toggle and builds the
+## container `args:` list from it.
+
+# -- option to override the name config in the _helpers.tpl
+nameOverride: ""
+# -- option to override the fullname config in the _helpers.tpl
+fullnameOverride: ""
+
+image:
+  # -- coraine image name
+  # ref: https://quay.io/repository/seamware/coraine
+  repository: quay.io/seamware/coraine
+  # -- tag of the image to be used, defaults to the chart's appVersion ("latest") when empty.
+  # Coraine ships no semver releases upstream (only `latest` or a git-sha tag) -- pin a
+  # git-sha tag here for reproducible deployments.
+  tag: ""
+  # -- specification of the image pull policy
+  pullPolicy: IfNotPresent
+
+# -- secrets to use for pulling the (private) coraine image
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+
+# -- if a coraine specific service account should be used, it can be configured here
+serviceAccount:
+  # -- specifies if the account should be created
+  create: false
+  # -- name of the service account to use, defaults to the fullname template when create is true
+  name: ""
+  # -- additional annotations for the service account
+  annotations: {}
+
+# -- number of coraine replicas. Only combine with `ha.enabled` when running against a
+# shared MongoDB replica set -- otherwise each replica has its own inconsistent state.
+replicaCount: 1
+
+# -- additional labels for the pod
+podLabels: {}
+# -- additional annotations for the pod
+podAnnotations: {}
+
+# -- pod-level security context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- container-level security context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# -- resource requests/limits for the coraine container. Left empty so that setting them
+# (e.g. for autoscaling) is a conscious choice by the user.
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## liveness/readiness probes. `/ngsi-ld/v1/types` needs no parameters or request body and,
+## with the mongoc backend, round-trips to the database -- so it doubles as a DB-reachability
+## check (matches the Dockerfile's own HEALTHCHECK).
+livenessProbe:
+  httpGet:
+    path: /ngsi-ld/v1/types
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /ngsi-ld/v1/types
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+## configuration for the k8s service in front of coraine
+service:
+  # -- service type
+  type: ClusterIP
+  # -- port to be used by the service
+  port: 1026
+  # -- additional annotations, if required
+  annotations: {}
+
+## ingress configuration. Disabled by default -- when enabling it, only route the NGSI-LD
+## API paths you actually want to be public (e.g. `/ngsi-ld`). Do NOT add `/` or `/admin` to
+## `hosts[].paths` unless you mean to expose coraine's ops/admin API to the internet; use
+## `exposeAdminPaths` below instead, which makes that an explicit, auditable opt-in.
+ingress:
+  # -- should there be an ingress to connect coraine with the public internet
+  enabled: false
+  # -- ingress class to use
+  className: ""
+  # -- annotations to be added to the ingress
+  annotations: {}
+    # kubernetes.io/tls-acme: "true"
+  # -- all hosts to be provided
+  hosts: []
+    # - host: coraine.example.org
+    #   paths:
+    #   - /ngsi-ld
+  # -- configure the ingress' tls
+  tls: []
+    # - secretName: coraine-tls
+    #   hosts:
+    #     - coraine.example.org
+  # -- ADVANCED / SECURITY-SENSITIVE: also route `/admin` and `/metrics` through this
+  # ingress, for every host in `hosts` above. These paths let a caller read tenant names,
+  # broker version/plugin info and mutate log verbosity at runtime (see coraine's admin
+  # plugin docs) -- keep this false unless the ingress itself is otherwise access-controlled
+  # (auth annotations, allow-list, mTLS, ...).
+  exposeAdminPaths: false
+
+## openshift specific route definition. Will not work on plain k8s. Same admin-path caveat
+## as `ingress.exposeAdminPaths` applies -- a Route has no path-based exposure control here,
+## so only enable this once `apiPlugins.admin.enabled` is false or the route is otherwise
+## access-controlled.
+route:
+  # -- should the deployment create an openshift route
+  enabled: false
+  # -- annotations to be added to the route
+  annotations: {}
+  # -- host to be used
+  # host: coraine.example.org
+  # -- tls configuration for the route
+  tls: {}
+    # termination: edge
+
+## pod autoscaling configuration
+autoscaling:
+  # -- should autoscaling be enabled for coraine
+  enabled: false
+  # -- apiVersion of the HorizontalPodAutoscaler resource
+  apiVersion: "v2"
+  # -- minimum number of running pods
+  minReplicas: 1
+  # -- maximum number of running pods
+  maxReplicas: 10
+  # -- list of MetricSpecs to decide whether to scale
+  metrics: []
+    # - type: Resource
+    #   resource:
+    #     name: cpu
+    #     target:
+    #       type: Utilization
+    #       averageUtilization: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+## general broker/server configuration (coraine core CLI flags)
+config:
+  # -- port coraine listens on (also used as the container port and default probe port)
+  port: 1026
+  # -- indent JSON responses (--pretty-print)
+  prettyPrint: false
+  # -- libmicrohttpd connection pool size (--connectionPoolSize)
+  connectionPoolSize: 32
+  # -- maximum accepted request body size in MiB, 0 = uncapped (--maxRequestSize)
+  maxRequestSize: 2
+  # -- default @context URL to use when a request supplies none (--defaultUserContext)
+  defaultUserContext: ""
+  # -- trace level string, e.g. "1-10" (--traceLevels)
+  traceLevels: ""
+  # -- suppress notifications whose payload did not actually change (--notifyValueChangeOnly)
+  notifyValueChangeOnly: false
+  # -- use nanosecond (9-digit) timestamps instead of microsecond (6-digit) ones (--high-precision)
+  highPrecision: false
+  # -- run snapshot queries in a background thread (--asyncSnapshot)
+  asyncSnapshot: false
+  # -- seconds between periodic subscription-stats flushes, 0 = disabled (--subStatsFlushInterval)
+  subStatsFlushInterval: 60
+  # -- HTTP client timeout in ms for distributed ops / notifications / context downloads (--distOpTimeout)
+  distOpTimeout: 5000
+  # -- default endpoint cooldown in ms after a failed notify/forward (--cooldownMillis)
+  cooldownMillis: 30000
+  # -- accept self-signed TLS certs on outbound notifications/forwards (--insecureNotif)
+  insecureNotif: false
+  cors:
+    # -- enable CORS by setting an allowed origin (--corsOrigin). Use "__ALL" to allow any origin.
+    enabled: false
+    # -- allowed origin, or "__ALL" for any origin
+    origin: "__ALL"
+    # -- seconds a CORS preflight response may be cached (--corsMaxAge)
+    maxAge: 86400
+
+## distributed operations ("federation" across registered Context Sources). Off by default --
+## registrations are always stored/discoverable, nothing forwards without `enabled: true`.
+distributed:
+  # -- enable forwarding requests to registered Context Sources (--distributed)
+  enabled: false
+  # -- this broker's externally-reachable base URL, embedded in Link headers/callbacks
+  # (--httpEndpoint). Leave empty to fall back to coraine's own auto-detection (which picks a
+  # pod-internal address and is almost never what you want in kubernetes) -- set it explicitly,
+  # e.g. "http://<release>-coraine.<namespace>.svc.cluster.local:1026" or your public ingress URL.
+  httpEndpoint: ""
+  # -- identity used for federation loop detection, derived from httpEndpoint when empty (--csourceAlias)
+  csourceAlias: ""
+  # -- disable splitting a single entity's attributes across multiple sources (--noSplitEntities)
+  noSplitEntities: false
+  # -- render a custom JSON document at /ngsi-ld/v1/info/sourceIdentity (--contextSourceExtras)
+  contextSourceExtras:
+    # -- if true, render `content` below into a ConfigMap and pass it via --contextSourceExtras.
+    # Leave false to use the image's built-in file (git sha / version / build time).
+    enabled: false
+    # -- arbitrary JSON content rendered verbatim at /ngsi-ld/v1/info/sourceIdentity
+    content: {}
+
+## database backend (--database). "mongoc" is the default and requires an external MongoDB;
+## "corRamDB" is a zero-dependency, non-persistent in-memory store useful for a quickstart/dev
+## deployment.
+database:
+  # -- database plugin to load: "mongo" (alias for "mongoc") or "memory" (alias for "corRamDB").
+  # The upstream plugin names "mongoc"/"corRamDB" also work directly; any other value is
+  # rejected -- see the note on dynamic plugin loading above.
+  type: mongo
+  mongoc:
+    # -- mongo host (--dbHost)
+    host: mongodb
+    # -- mongo port (--dbPort)
+    port: 27017
+    # -- mongo database name (--dbName)
+    name: cor
+    # -- reserved mongo database for global/non-tenant state, e.g. cached JSON-LD contexts (--globalDb)
+    globalDb: coraine
+    # -- mongo connection timeout in seconds (--dbTimeout)
+    timeout: 30
+    auth:
+      # -- enable mongo authentication (--dbUser / --dbPwd)
+      enabled: false
+      # -- mongo username (--dbUser)
+      user: ""
+      # -- mongo password (--dbPwd), ignored when existingSecret is set. Passed to coraine via an
+      # env var + `$(...)` substitution so it is not baked in plaintext into the pod's args spec --
+      # note this is still visible in `ps`/`/proc` inside the container, coraine has no other way
+      # to receive it.
+      password: ""
+      # -- reference an existing secret instead of `password` above.
+      # existingSecret:
+      #   name: coraine-db-credentials
+      #   key: dbPassword
+      existingSecret: {}
+    uri:
+      # -- use a full mongo connection URI instead of host/port/user/pwd (--dbURI). Overrides all
+      # other mongoc.* settings above when enabled.
+      enabled: false
+      # -- the connection URI, ignored when existingSecret is set
+      value: ""
+      # -- reference an existing secret instead of `value` above.
+      # existingSecret:
+      #   name: coraine-db-credentials
+      #   key: dbURI
+      existingSecret: {}
+
+## temporal history / TRoE (--troe). "none" disables it; "ramdb" is in-memory/dev-only;
+## "timescale" persists to an external TimescaleDB/postgres instance.
+troe:
+  # -- temporal history plugin to load: "none", "ramdb" or "timescale"
+  type: none
+  timescale:
+    # -- timescale/postgres host (--troeHost)
+    host: timescaledb
+    # -- timescale/postgres port (--troePort)
+    port: 5432
+    # -- timescale/postgres database name (--troeName)
+    name: corh
+    # -- timescale/postgres user (--troeUser)
+    user: postgres
+    # -- timescale/postgres password (--troePwd), ignored when existingSecret is set. Same
+    # `$(...)` env-var substitution caveat as database.mongoc.auth.password applies.
+    password: ""
+    # -- reference an existing secret instead of `password` above.
+    # existingSecret:
+    #   name: coraine-troe-credentials
+    #   key: troePassword
+    existingSecret: {}
+    # -- connection pool size (--troePoolSize)
+    poolSize: 10
+    # -- max number of temporal instances kept in memory before eviction (--troeInstanceCap)
+    instanceCap: 1000000
+
+## high availability. Only "mongo" is implemented upstream today (syncs broker instance
+## caches across replicas via MongoDB change streams; requires database.type=mongoc against
+## a real replica set). Any other upstream value is explicitly rejected by coraine itself.
+ha:
+  # -- enable multi-replica cache sync via MongoDB change streams (--ha mongo)
+  enabled: false
+
+## API plugins (--apiPlugins). Only "admin" ships upstream today; it adds the ops/admin
+## endpoints (see ingress.exposeAdminPaths above for public-exposure control) plus the
+## /metrics and /admin/metrics Prometheus scrape endpoints.
+apiPlugins:
+  admin:
+    # -- load the admin/ops API plugin (--apiPlugins admin). Required for /metrics,
+    # /admin/tenants, /admin/plugins, /admin/log, etc. The k8s Service always exposes these
+    # cluster-internally when enabled; see `ingress.exposeAdminPaths` to also expose them
+    # externally.
+    enabled: true
+
+## prometheus scrape annotations for the pod. Requires apiPlugins.admin.enabled.
+metrics:
+  # -- add prometheus.io/scrape annotations to the pod (served at /metrics by the admin plugin)
+  enabled: false
+
+# -- additional environment variables to set on the coraine container
+# ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+extraEnvVars: []
+  # - name: SOME_VAR
+  #   value: "some-value"
+
+# -- name of an existing Secret to load as additional environment variables (envFrom)
+extraEnvVarsSecret: ""
+
+# -- extra command-line flags appended verbatim after the ones generated from `config`/
+# `database`/`troe`/etc above, for coraine options this chart does not (yet) model directly
+extraArgs: []
+  # - "--traceLevels"
+  # - "1-10"
+
+# -- additional volumes on the coraine pod
+extraVolumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+
+# -- additional volumeMounts on the coraine container
+extraVolumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+# -- additional Kubernetes manifests to render alongside this chart's own resources. Each
+# entry is rendered with `tpl`, so it may reference `.Release`, `.Values`, etc.
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: coraine-extra
+  #   data:
+  #     foo: bar


### PR DESCRIPTION
Adds a new chart for deploying SEAMWARE Coraine, following the fiware helm-charts conventions (common library helpers, extraEnvVars/extraArgs/ extraVolumes/extraManifests overrides). Admin/metrics endpoints are not routed through the ingress by default, and only the plugins bundled in the image (mongo/mongoc, memory/corRamDB, none/ramdb/timescale, admin) can be selected -- dynamic loading of custom plugins is out of scope.